### PR TITLE
Fix downloading behind proxy

### DIFF
--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -338,16 +338,25 @@ listEnv = Array(_
 Function DownloadFile(strUrl,strFile)
     Dim objHttp
     Dim httpProxy
-    Set objHttp = WScript.CreateObject("Msxml2.ServerXMLHTTP")
+    Dim proxyArr
+    Set objHttp = WScript.CreateObject("WinHttp.WinHttpRequest.5.1")
     on error resume next
+    httpProxy = objws.ExpandEnvironmentStrings("%http_proxy%")
+    if httpProxy <> "" AND httpProxy <> "%http_proxy%" Then
+        if InStr(1, httpProxy, "@") > 0 then
+            ' The http_proxy environment variable is set with basic authentication
+            ' WinHttp seems to work fine without the credentials, so we should be
+            ' okay with just the hostname/port part
+            proxyArr = Split(httpProxy, "@")
+            objHttp.setProxy 2, proxyArr(1)
+        else
+            objHttp.setProxy 2, httpProxy
+        end if
+    end if
     Call objHttp.Open("GET", strUrl, False )
     if Err.Number <> 0 then
         WScript.Echo Err.Description
         WScript.Quit
-    end if
-    httpProxy = objws.ExpandEnvironmentStrings("%http_proxy%")
-    if httpProxy <> "" AND httpProxy <> "%http_proxy%" Then
-        objHttp.setProxy 2, httpProxy
     end if
     objHttp.Send
 


### PR DESCRIPTION
Fixes #20. Summary of changes:

* `MsXml.ServerXmlHTTP` replaced with `WinHttp.WinHttpRequest.5.1`
* Proxy configuration code moved before the call to `Open`
* Some additional logic added to handle proxy environment variables with basic auth configured (we don't use the credentials but we need to account for them when parsing the env var)

I tried various approaches but couldn't get ServerXmlHttp to work with the proxy settings. It kept failing with
```
System error: -2147012796.
```

I was unable to find any information on this error code, or why it didn't work, but after a bit more digging, I was able to find some documentation for WinHttp which seemed newer, so I thought I'd give that a shot. It worked on my machine (Windows 10 Pro), behind a proxy 