### PR TITLE
Added support for 'pyenv which' (also whence and version-name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,19 @@ I found a similar system for [rbenv-win][3] for ruby developers. This project wa
 ## pyenv-win commands
 
 ```yml
-   commands    List all available pyenv commands
-   local       Set or show the local application-specific Python version
-   global      Set or show the global Python version
-   shell       Set or show the shell-specific Python version
-   install     Install a Python version using python-build
-   uninstall   Uninstall a specific Python version
-   rehash      Rehash pyenv shims (run this after installing executables)
-   version     Show the current Python version and its origin
-   versions    List all Python versions available to pyenv
-   exec        Runs an executable by first preparing PATH so that the selected Python
+   commands     List all available pyenv commands
+   local        Set or show the local application-specific Python version
+   global       Set or show the global Python version
+   shell        Set or show the shell-specific Python version
+   install      Install a Python version using python-build
+   uninstall    Uninstall a specific Python version
+   rehash       Rehash pyenv shims (run this after installing executables)
+   version      Show the current Python version and its origin
+   version-name Show the current Python version
+   versions     List all Python versions available to pyenv
+   exec         Runs an executable by first preparing PATH so that the selected Python
+   which        Display the full path to an executable
+   whence       List all Python versions that contain the given executable
 ```
 
 ## Installation

--- a/pyenv-win/libexec/pyenv-version-name.bat
+++ b/pyenv-win/libexec/pyenv-version-name.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+
+if "%1" == "--help" (
+echo Usage: pyenv version-name
+echo.
+echo Shows the currently selected Python version.
+EXIT /B
+)
+
+:: Implementation of this command is in the pyenv.vbs file

--- a/pyenv-win/libexec/pyenv-version.bat
+++ b/pyenv-win/libexec/pyenv-version.bat
@@ -4,8 +4,8 @@ setlocal
 if "%1" == "--help" (
 echo Usage: pyenv version
 echo.
-echo Shows the currently selected Python version and how it was
-echo selected. To obtain only the version string, use `pyenv version'.
+echo Shows the currently selected Python version and how it was selected.
+echo To obtain only the version string, use `pyenv version-name'.
 EXIT /B
 )
 

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -126,6 +126,19 @@ Function GetCommandList()
     Set GetCommandList = cmdList
 End Function
 
+Function PyExtensions()
+    Dim exts
+    exts = ";"& objws.Environment("Process")("PATHEXT") &";"
+
+    If InStr(1, exts, ";.PY;", 1) = 0 Then exts = exts &".PY;"
+    If InStr(1, exts, ";.PYW;", 1) = 0 Then exts = exts &".PYW;"
+    exts = Mid(exts, 2, Len(exts)-2)
+    Do While InStr(1, exts, ";;", 1) <> 0
+        exts = Replace(exts, ";;", ";")
+    Loop
+    PyExtensions = Split(exts, ";")
+End Function
+
 Sub PrintHelp(cmd, exitCode)
     Dim help
     help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat --help")
@@ -198,7 +211,7 @@ Sub CommandWhich(arg)
     If version = "" Then version = GetCurrentVersion()(0)
     If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
 
-    exts = Split(objws.Environment("Process")("PATHEXT"), ";")
+    exts = PyExtensions()
 
     If Not objfs.FolderExists(strDirVers &"\"& version) Then
         WScript.Echo "pyenv: version `"& version &"' is not installed (set by "& version &")"
@@ -269,7 +282,7 @@ Sub CommandWhence(arg)
     If program = "" Then PrintHelp "pyenv-whence", 1
     If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
 
-    exts = Split(objws.Environment("Process")("PATHEXT"), ";")
+    exts = PyExtensions()
     foundAny = 1
 
     For Each dir In objfs.GetFolder(strDirVers).subfolders

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -70,7 +70,7 @@ Function GetCurrentVersionShell()
     GetCurrentVersionShell = Null
 
     Dim str
-    str=objws.ExpandEnvironmentStrings("%PYENV_VERSION%")
+    str = objws.ExpandEnvironmentStrings("%PYENV_VERSION%")
     If str <> "%PYENV_VERSION%" Then
         GetCurrentVersionShell = Array(str,"%PYENV_VERSION%")
     End If
@@ -78,20 +78,20 @@ End Function
 
 Function GetCurrentVersion()
     Dim str
-    str=GetCurrentVersionShell
+    str = GetCurrentVersionShell
     If IsNull(str) Then str = GetCurrentVersionLocal(strCurrent)
     If IsNull(str) Then str = GetCurrentVersionGlobal
     If IsNull(str) Then 
-		WScript.echo "No global python version has been set yet. Please set the global version by typing:"
-		WScript.echo "pyenv global 3.7.2"
-		WScript.quit
-	End If
-	GetCurrentVersion = str
+        WScript.Echo "No global python version has been set yet. Please set the global version by typing:"
+        WScript.Echo "pyenv global 3.7.2"
+        WScript.Quit
+    End If
+    GetCurrentVersion = str
 End Function
 
 Function GetCurrentVersionNoError()
     Dim str
-    str=GetCurrentVersionShell
+    str = GetCurrentVersionShell
     If IsNull(str) Then str = GetCurrentVersionLocal(strCurrent)
     If IsNull(str) Then str = GetCurrentVersionGlobal
     GetCurrentVersionNoError = str
@@ -99,12 +99,12 @@ End Function
 
 Function GetBinDir(ver)
     Dim str
-    str=strDirVers & "\" & ver & "\" 
+    str = strDirVers & "\" & ver & "\" 
     If Not(IsVersion(ver) And objfs.FolderExists(str)) Then 
-		WScript.echo "pyenv specific python requisite didn't meet. Project is using different version of python."
-		WScript.echo "Install python '"&ver&"' by typing: 'pyenv install "&ver&"'"
-		WScript.quit
-	End If
+        WScript.Echo "pyenv specific python requisite didn't meet. Project is using different version of python."
+        WScript.Echo "Install python '"&ver&"' by typing: 'pyenv install "&ver&"'"
+        WScript.Quit
+    End If
     GetBinDir = str
 End Function
 
@@ -119,7 +119,7 @@ Function GetCommandList()
     Dim file
     Dim mts
     For Each file In objfs.GetFolder(strDirLibs).Files
-        Set mts=re.Execute(file)
+        Set mts = re.Execute(file)
         If mts.Count > 0 Then
              cmdList.Add mts(0).submatches(0), file
         End If
@@ -145,73 +145,73 @@ end Function
 
 Sub CommandShims(arg)
      Dim shims_files
-     If arg.Count < 2 then
-     ' WScript.echo join(arg.ToArray(), ", ")
+     If arg.Count < 2 Then
+     ' WScript.Echo join(arg.ToArray(), ", ")
      ' if --short passed then remove /s from cmd
         shims_files = getCommandOutput("cmd /c dir "&strDirShims&"/s /b")
-     ElseIf arg(1) = "--short" then
+     ElseIf arg(1) = "--short" Then
         shims_files = getCommandOutput("cmd /c dir "&strDirShims&" /b")
      Else
         shims_files = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shims.bat --help")
      End IF
-     WScript.echo shims_files
+     WScript.Echo shims_files
 End Sub
 
 Sub CommandWhich(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-which.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
-     WScript.echo "TO be added"
+     WScript.Echo "TO be added"
 End Sub
 
 Sub CommandWhence(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-whence.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
-     WScript.echo "TO be added"
+     WScript.Echo "TO be added"
 End Sub
 
 Sub ShowHelp()
-     WScript.echo "pyenv " & objfs.OpenTextFile(strPyenvParent & "\.version").ReadAll
-     WScript.echo "Usage: pyenv <command> [<args>]"
-     WScript.echo ""
-     WScript.echo "Some useful pyenv commands are:"
-     WScript.echo "   commands    List all available pyenv commands"
-     WScript.echo "   duplicate   Creates a duplicate python environment"
-     WScript.echo "   local       Set or show the local application-specific Python version"
-     WScript.echo "   global      Set or show the global Python version"
-     WScript.echo "   shell       Set or show the shell-specific Python version"
-     WScript.echo "   install     Install a Python version using python-build"
-     WScript.echo "   uninstall   Uninstall a specific Python version"
-     WScript.echo "   rehash      Rehash pyenv shims (run this after installing executables)"
-     WScript.echo "   version     Show the current Python version and its origin"
-     WScript.echo "   versions    List all Python versions available to pyenv"
-     WScript.echo "   exec        Runs an executable by first preparing PATH so that the selected Python"
-     WScript.echo "   which       Display the full path to an executable"
-     WScript.echo "   whence      List all Python versions that contain the given executable"
-     WScript.echo ""
-     WScript.echo "See `pyenv help <command>' for information on a specific command."
-     WScript.echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
+     WScript.Echo "pyenv " & objfs.OpenTextFile(strPyenvParent & "\.version").ReadAll
+     WScript.Echo "Usage: pyenv <command> [<args>]"
+     WScript.Echo ""
+     WScript.Echo "Some useful pyenv commands are:"
+     WScript.Echo "   commands    List all available pyenv commands"
+     WScript.Echo "   duplicate   Creates a duplicate python environment"
+     WScript.Echo "   local       Set or show the local application-specific Python version"
+     WScript.Echo "   global      Set or show the global Python version"
+     WScript.Echo "   shell       Set or show the shell-specific Python version"
+     WScript.Echo "   install     Install a Python version using python-build"
+     WScript.Echo "   uninstall   Uninstall a specific Python version"
+     WScript.Echo "   rehash      Rehash pyenv shims (run this after installing executables)"
+     WScript.Echo "   version     Show the current Python version and its origin"
+     WScript.Echo "   versions    List all Python versions available to pyenv"
+     WScript.Echo "   exec        Runs an executable by first preparing PATH so that the selected Python"
+     WScript.Echo "   which       Display the full path to an executable"
+     WScript.Echo "   whence      List all Python versions that contain the given executable"
+     WScript.Echo ""
+     WScript.Echo "See `pyenv help <command>' for information on a specific command."
+     WScript.Echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
 End Sub
 
 Sub CommandHelp(arg)
     If arg.Count > 1 Then
         Dim list
-        Set list=GetCommandList
+        Set list = GetCommandList
         If list.Exists(arg(1)) Then
             ExecCommand(list(arg(1)) & " --help")
         Else
-             WScript.echo "unknown pyenv command '"&arg(1)&"'"
+             WScript.Echo "unknown pyenv command '"& arg(1) &"'"
         End If
     Else
         ShowHelp
@@ -220,16 +220,16 @@ End Sub
 
 
 Sub CommandRehash(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-rehash.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
-    Dim strDirShims
-    strDirShims= strPyenvHome & "\shims"
+    Dim strDirBin
+    strDirBin = GetBinDir(GetCurrentVersion()(0))
     If Not objfs.FolderExists( strDirShims ) Then objfs.CreateFolder(strDirShims)
 
     Dim ofile
@@ -238,7 +238,7 @@ Sub CommandRehash(arg)
         objfs.DeleteFile file, True
     Next
 
-    For Each file In objfs.GetFolder(GetBinDir(GetCurrentVersion()(0))).Files
+    For Each file In objfs.GetFolder(strDirBin).Files
         If objfs.GetExtensionName(file) = "exe" or objfs.GetExtensionName(file) = "bat" or objfs.GetExtensionName(file) = "cmd" or objfs.GetExtensionName(file) = "py" Then
           Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) & ".bat" )
           ofile.WriteLine("@echo off")
@@ -250,9 +250,9 @@ Sub CommandRehash(arg)
           ofile.Close()
         End If
     Next
-    
-    If objfs.FolderExists(GetBinDir(GetCurrentVersion()(0)) & "\Scripts") Then
-        For Each file In objfs.GetFolder(GetBinDir(GetCurrentVersion()(0)) & "\Scripts").Files
+
+    If objfs.FolderExists(strDirBin & "\Scripts") Then
+        For Each file In objfs.GetFolder(strDirBin & "\Scripts").Files
             If objfs.GetExtensionName(file) = "exe" or objfs.GetExtensionName(file) = "bat" or objfs.GetExtensionName(file) = "cmd" or objfs.GetExtensionName(file) = "py" Then
             Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) & ".bat" )
             ofile.WriteLine("@echo off")
@@ -268,24 +268,24 @@ Sub CommandRehash(arg)
 End Sub
 
 Sub CommandExecute(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-exec.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
     Dim str
     Dim dstr
-    dstr=GetBinDir(GetCurrentVersion()(0))
-    str="set PATH=" & dstr & ";%PATH:&=^&%" & vbCrLf
+    dstr = GetBinDir(GetCurrentVersion()(0))
+    str = "set PATH=" & dstr & ";%PATH:&=^&%" & vbCrLf
     If arg.Count > 1 Then  
-      str=str & """" & dstr & "\" & arg(1) & """"
+      str = str & """" & dstr & "\" & arg(1) & """"
       Dim idx
       If arg.Count > 2 Then  
         For idx = 2 To arg.Count - 1 
-          str=str & " """& arg(idx) &""""
+          str = str & " """& arg(idx) &""""
         Next
       End If
     End If
@@ -293,21 +293,21 @@ Sub CommandExecute(arg)
 End Sub
 
 Sub CommandGlobal(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-global.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
     If arg.Count < 2 Then  
         Dim ver
-        ver=GetCurrentVersionGlobal()
+        ver = GetCurrentVersionGlobal()
         If IsNull(ver) Then
-            WScript.echo "no global version configured"
+            WScript.Echo "no global version configured"
         Else
-            WScript.echo ver(0)
+            WScript.Echo ver(0)
         End If
     Else
         GetBinDir(arg(1))
@@ -319,24 +319,24 @@ Sub CommandGlobal(arg)
 End Sub
 
 Sub CommandLocal(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-local.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
     Dim ver
     If arg.Count < 2 Then  
-        ver=GetCurrentVersionLocal(strCurrent)
+        ver = GetCurrentVersionLocal(strCurrent)
         If IsNull(ver) Then
-            WScript.echo "no local version configured for this directory"
+            WScript.Echo "no local version configured for this directory"
         Else
-            WScript.echo ver(0)
+            WScript.Echo ver(0)
         End If
     Else
-        ver=arg(1)
+        ver = arg(1)
         If ver = "--unset" Then
             ver = ""
             objfs.DeleteFile strCurrent & strVerFile, True
@@ -356,24 +356,24 @@ Sub CommandLocal(arg)
 End Sub
 
 Sub CommandShell(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shell.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
     Dim ver
     If arg.Count < 2 Then  
-        ver=GetCurrentVersionShell
+        ver = GetCurrentVersionShell
         If IsNull(ver) Then
-            WScript.echo "no shell-specific version configured"
+            WScript.Echo "no shell-specific version configured"
         Else
-            WScript.echo ver(0)
+            WScript.Echo ver(0)
         End If
     Else
-        ver=arg(1)
+        ver = arg(1)
         If ver = "--unset" Then
             ver = ""
         Else
@@ -384,10 +384,10 @@ Sub CommandShell(arg)
 End Sub
 
 Sub CommandVersion(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-version.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
@@ -395,52 +395,52 @@ Sub CommandVersion(arg)
     If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
 
     Dim curVer
-    curVer=GetCurrentVersion
-    WScript.echo curVer(0) & " (set by " &curVer(1)&")"
+    curVer = GetCurrentVersion
+    WScript.Echo curVer(0) & " (set by " &curVer(1)&")"
 End Sub
 
 Sub CommandVersions(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-versions.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
     Dim isBare
-    isBare=False
+    isBare = False
     If arg.Count >= 2 Then
-        If arg(1) = "--bare" Then isBare=True
+        If arg(1) = "--bare" Then isBare = True
     End If
 
     If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
 
     Dim curVer
-    curVer=GetCurrentVersionNoError
+    curVer = GetCurrentVersionNoError
     If IsNull(curVer) Then
-        curVer=Array("","")
+        curVer = Array("","")
     End If
 
     Dim dir
     Dim ver
     For Each dir In objfs.GetFolder(strDirVers).subfolders
-        ver=objfs.GetFileName( dir )
+        ver = objfs.GetFileName( dir )
         If isBare Then
-            WScript.echo ver
+            WScript.Echo ver
         ElseIf ver = curVer(0) Then
-            WScript.echo "* " & ver & " (set by " &curVer(1)&")"
+            WScript.Echo "* " & ver & " (set by " &curVer(1)&")"
         Else
-            WScript.echo "  " & ver
+            WScript.Echo "  " & ver
         End If
     Next
 End Sub
 
 Sub PlugIn(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-"&arg(0)&".bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
@@ -450,16 +450,16 @@ Sub PlugIn(arg)
     Dim str
     fname = strDirLibs & "\pyenv-" & arg(0)
     If objfs.FileExists( fname & ".bat" ) Then
-        str="""" & fname & ".bat"""
+        str = """" & fname & ".bat"""
     ElseIf objfs.FileExists( fname & ".vbs" ) Then
-        str="cscript //nologo """ & fname & ".vbs"""
+        str = "cscript //nologo """ & fname & ".vbs"""
     Else
-       WScript.echo "pyenv: no such command `"&arg(0)&"'"
+       WScript.Echo "pyenv: no such command `"&arg(0)&"'"
        WScript.Quit
     End If
 
     For idx = 1 To arg.Count - 1 
-      str=str & " """& arg(idx) &""""
+      str = str & " """& arg(idx) &""""
     Next
 
     ExecCommand(str)
@@ -468,21 +468,21 @@ End Sub
 Sub CommandCommands(arg)
     Dim cname
 
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then
             help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-commands.bat --help")
-            WScript.echo help
+            WScript.Echo help
             Exit Sub
         End If
     End If
 
     For Each cname In GetCommandList()
-        WScript.echo cname
+        WScript.Echo cname
     Next
 End Sub
 
 Sub Dummy()
-     WScript.echo "command not implement"
+     WScript.Echo "command not implement"
 End Sub
 
 
@@ -508,7 +508,5 @@ Sub main(arg)
         End Select
     End If
 End Sub
-
-
 
 main(WScript.Arguments)

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -179,7 +179,85 @@ Sub CommandWhence(arg)
         PrintHelp "pyenv-whence", Abs(arg(1) = "")
     End If
 
-     WScript.Echo "TO be added"
+    Dim program
+    Dim exts
+    Dim ext
+    dim path
+    Dim dir
+    Dim isPath
+    Dim found
+    Dim foundAny ' Acts as an exit code: 0=Success, 1=No files/versions found
+
+    If arg(1) = "--path" Then
+        If arg.Count < 3 Then PrintHelp "pyenv-whence", 1
+        isPath = True
+        program = arg(2)
+    Else
+        program = arg(1)
+    End If
+
+    If program = "" Then PrintHelp "pyenv-whence", 1
+    If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
+
+    exts = Split(objws.Environment("Process")("PATHEXT"), ";")
+    foundAny = 1
+
+    For Each dir In objfs.GetFolder(strDirVers).subfolders
+        found = False
+
+        If objfs.FileExists(dir & "\" & program) Then
+            found = True
+            foundAny = 0
+            If isPath Then
+                WScript.Echo objfs.GetFile(dir & "\" & program).Path
+            Else
+                WScript.Echo objfs.GetFileName( dir )
+            End If
+        End If
+
+        If Not found Or isPath Then
+            For Each ext In exts
+                If objfs.FileExists(dir & "\" & program & ext) Then
+                    found = True
+                    foundAny = 0
+                    If isPath Then
+                        WScript.Echo objfs.GetFile(dir & "\" & program & ext).Path
+                    Else
+                        WScript.Echo objfs.GetFileName( dir )
+                    End If
+                    Exit For
+                End If
+            Next
+        End If
+
+        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
+            If objfs.FileExists(dir & "\Scripts\" & program) Then
+                found = True
+                foundAny = 0
+                If isPath Then
+                    WScript.Echo objfs.GetFile(dir & "\Scripts\" & program).Path
+                Else
+                    WScript.Echo objfs.GetFileName( dir )
+                End If
+            End If
+        End If
+
+        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
+            For Each ext In exts
+                If objfs.FileExists(dir & "\Scripts\" & program & ext) Then
+                    foundAny = 0
+                    If isPath Then
+                        WScript.Echo objfs.GetFile(dir & "\Scripts\" & program & ext).Path
+                    Else
+                        WScript.Echo objfs.GetFileName( dir )
+                    End If
+                    Exit For
+                End If
+            Next
+        End If
+    Next
+
+    WScript.Quit foundAny
 End Sub
 
 Sub ShowHelp()

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -23,8 +23,6 @@ strDirLibs   = strPyenvHome & "\libexec"
 strDirShims  = strPyenvHome & "\shims"
 strVerFile   = "\.python-version"
 
-Dim help
-
 Function IsVersion(version)
     Dim re
     Set re = new regexp
@@ -128,6 +126,13 @@ Function GetCommandList()
     Set GetCommandList = cmdList
 End Function
 
+Sub PrintHelp(cmd, exitCode)
+    Dim help
+    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat --help")
+    WScript.Echo help
+    WScript.Quit exitCode
+End Sub
+
 Sub ExecCommand(str)
     Dim ofile
     Set ofile = CreateObject("ADODB.Stream")
@@ -158,24 +163,20 @@ Sub CommandShims(arg)
 End Sub
 
 Sub CommandWhich(arg)
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-which.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+    If arg.Count < 2 Then
+        PrintHelp "pyenv-which", 1
+    ElseIf arg(1) = "--help" Or arg(1) = "" Then
+        PrintHelp "pyenv-which", Abs(arg(1) = "")
     End If
 
      WScript.Echo "TO be added"
 End Sub
 
 Sub CommandWhence(arg)
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-whence.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+    If arg.Count < 2 Then
+        PrintHelp "pyenv-whence", 1
+    ElseIf arg(1) = "--help" Or arg(1) = "" Then
+        PrintHelp "pyenv-whence", Abs(arg(1) = "")
     End If
 
      WScript.Echo "TO be added"
@@ -221,11 +222,7 @@ End Sub
 
 Sub CommandRehash(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-rehash.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-rehash", 0
     End If
 
     Dim strDirBin
@@ -269,11 +266,7 @@ End Sub
 
 Sub CommandExecute(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-exec.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-exec", 0
     End If
 
     Dim str
@@ -294,11 +287,7 @@ End Sub
 
 Sub CommandGlobal(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-global.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-global", 0
     End If
 
     If arg.Count < 2 Then  
@@ -320,11 +309,7 @@ End Sub
 
 Sub CommandLocal(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-local.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-local", 0
     End If
 
     Dim ver
@@ -357,11 +342,7 @@ End Sub
 
 Sub CommandShell(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shell.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-shell", 0
     End If
 
     Dim ver
@@ -385,11 +366,7 @@ End Sub
 
 Sub CommandVersion(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-version.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-version", 0
     End If
 
     If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
@@ -401,11 +378,7 @@ End Sub
 
 Sub CommandVersions(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-versions.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-versions", 0
     End If
 
     Dim isBare
@@ -438,11 +411,7 @@ End Sub
 
 Sub PlugIn(arg)
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-"&arg(0)&".bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-"& arg(0), 0
     End If
 
     Dim fname
@@ -469,11 +438,7 @@ Sub CommandCommands(arg)
     Dim cname
 
     If arg.Count >= 2 Then
-        If arg(1) = "--help" Then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-commands.bat --help")
-            WScript.Echo help
-            Exit Sub
-        End If
+        If arg(1) = "--help" Then PrintHelp "pyenv-commands", 0
     End If
 
     For Each cname In GetCommandList()

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -187,19 +187,20 @@ Sub ShowHelp()
      WScript.Echo "Usage: pyenv <command> [<args>]"
      WScript.Echo ""
      WScript.Echo "Some useful pyenv commands are:"
-     WScript.Echo "   commands    List all available pyenv commands"
-     WScript.Echo "   duplicate   Creates a duplicate python environment"
-     WScript.Echo "   local       Set or show the local application-specific Python version"
-     WScript.Echo "   global      Set or show the global Python version"
-     WScript.Echo "   shell       Set or show the shell-specific Python version"
-     WScript.Echo "   install     Install a Python version using python-build"
-     WScript.Echo "   uninstall   Uninstall a specific Python version"
-     WScript.Echo "   rehash      Rehash pyenv shims (run this after installing executables)"
-     WScript.Echo "   version     Show the current Python version and its origin"
-     WScript.Echo "   versions    List all Python versions available to pyenv"
-     WScript.Echo "   exec        Runs an executable by first preparing PATH so that the selected Python"
-     WScript.Echo "   which       Display the full path to an executable"
-     WScript.Echo "   whence      List all Python versions that contain the given executable"
+     WScript.Echo "   commands     List all available pyenv commands"
+     WScript.Echo "   duplicate    Creates a duplicate python environment"
+     WScript.Echo "   local        Set or show the local application-specific Python version"
+     WScript.Echo "   global       Set or show the global Python version"
+     WScript.Echo "   shell        Set or show the shell-specific Python version"
+     WScript.Echo "   install      Install a Python version using python-build"
+     WScript.Echo "   uninstall    Uninstall a specific Python version"
+     WScript.Echo "   rehash       Rehash pyenv shims (run this after installing executables)"
+     WScript.Echo "   version      Show the current Python version and its origin"
+     WScript.Echo "   version-name Show the current Python version"
+     WScript.Echo "   versions     List all Python versions available to pyenv"
+     WScript.Echo "   exec         Runs an executable by first preparing PATH so that the selected Python"
+     WScript.Echo "   which        Display the full path to an executable"
+     WScript.Echo "   whence       List all Python versions that contain the given executable"
      WScript.Echo ""
      WScript.Echo "See `pyenv help <command>' for information on a specific command."
      WScript.Echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
@@ -376,6 +377,16 @@ Sub CommandVersion(arg)
     WScript.Echo curVer(0) & " (set by " &curVer(1)&")"
 End Sub
 
+Sub CommandVersionName(arg)
+    If arg.Count >= 2 Then
+        If arg(1) = "--help" Then PrintHelp "pyenv-version-name", 0
+    End If
+
+    If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
+
+    WScript.Echo GetCurrentVersion()(0)
+End Sub
+
 Sub CommandVersions(arg)
     If arg.Count >= 2 Then
         If arg(1) = "--help" Then PrintHelp "pyenv-versions", 0
@@ -456,20 +467,21 @@ Sub main(arg)
         ShowHelp
     Else
         Select Case arg(0)
-           Case "exec"        CommandExecute(arg)
-           Case "rehash"      CommandRehash(arg)
-           Case "global"      CommandGlobal(arg)
-           Case "local"       CommandLocal(arg)
-           Case "shell"       CommandShell(arg)
-           Case "version"     CommandVersion(arg)
-           Case "versions"    CommandVersions(arg)
-           Case "commands"    CommandCommands(arg)
-           Case "shims"       CommandShims(arg)
-           Case "which"       CommandWhich(arg)
-           Case "whence"      CommandWhence(arg)
-           Case "help"        CommandHelp(arg)
-           Case "--help"      CommandHelp(arg)
-           Case Else          PlugIn(arg)
+           Case "exec"         CommandExecute(arg)
+           Case "rehash"       CommandRehash(arg)
+           Case "global"       CommandGlobal(arg)
+           Case "local"        CommandLocal(arg)
+           Case "shell"        CommandShell(arg)
+           Case "version"      CommandVersion(arg)
+           Case "version-name" CommandVersionName(arg)
+           Case "versions"     CommandVersions(arg)
+           Case "commands"     CommandCommands(arg)
+           Case "shims"        CommandShims(arg)
+           Case "which"        CommandWhich(arg)
+           Case "whence"       CommandWhence(arg)
+           Case "help"         CommandHelp(arg)
+           Case "--help"       CommandHelp(arg)
+           Case Else           PlugIn(arg)
         End Select
     End If
 End Sub

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -37,6 +37,7 @@ class TestPyenv(TestPyenvBase):
         assert 'uninstall' in result
         assert 'rehash' in result
         assert 'version' in result
+        assert 'version-name' in result
         assert 'versions' in result
         assert 'exec' in result
         assert 'which' in result


### PR DESCRIPTION
Hi in regards to Issue #76 I made some baseline functionality that should closely match the original pyenv's whence/which commands (translated the current `pyenv` Bash into rough VBScript equivalents).

The only 2 main differences with this and the Linux `pyenv which/whence` commands are:

1. The new `pyenv which` currently doesn't support looking for executables across multiple installed versions, only the currently assigned one via global/local/shell/etc. (just like the other `pyenv-win` commands do currently)

  * Ex:
`pyenv global 3.6.8`
`pyenv which python` returns:
`.../pyenv-win/versions/3.6.8/python.exe`

  * Not:
`pyenv which python` returns:
`.../pyenv-win/versions/3.6.8/python.exe`
`.../pyenv-win/versions/3.7.0/python.exe`
`etc..`

2. The new `pyenv whence` supports finding multiple executable files (if they exist) in the python/Scripts folders via `%PATHEXT%` (.com, .exe, .bat, .cmd, .vbs, etc...) similar to how Window's `cmd where` works. (Looks across multiple installed versions of python just like original `pyenv whence` does though)

  * Ex (if you had custom_cmd.exe and custom_cmd.bat):
`pyenv whence --path custom_cmd` returns:
`.../pyenv-win/versions/3.6.8/custom_cmd.exe`
`.../pyenv-win/versions/3.6.8/custom_cmd.bat`
`.../pyenv-win/versions/3.6.8/Scripts/custom_cmd.exe`
`.../pyenv-win/versions/3.6.8/Scripts/custom_cmd.bat`
`.../pyenv-win/versions/3.7.0/custom_cmd.exe`
`.../pyenv-win/versions/3.7.0/custom_cmd.bat`
`.../pyenv-win/versions/3.7.0/Scripts/custom_cmd.exe`
`.../pyenv-win/versions/3.7.0/Scripts/custom_cmd.bat`

Also added `pyenv version-name` because I thought I needed it, then found out later I didn't but left it in anyway in case others did...

2 things I also noticed and wanted to ask about/comment on while adding these was:

1. Most of the other commands don't properly return an Exit Code (`WScript.Quit()` not being used) when they complete or error, which makes checking for errors from pyenv-win unusable in scripting (%ERRORLEVEL%=0). I've added my functions to correctly mirror Linux's `pyenv` behavior (and refactored all of the `--help` in `pyenv.vbs` to support exit codes like Linux's `pyenv`) but should full exit code handling support be added as a new issue and PR?
2. `pyenv rehash` has certain file extensions hard-coded into it (exe, cmd, bat, py) and doesn't recognize %PATHEXT% extensions, since I made a helper function for that, do you want me to submit a new PR with `pyenv rehash` refactored to support that too? (I already made a new branch in my repo with it partially refactored since it'd be fairly trivial with the helper function now)