### PR TITLE
Feature: No cp65001

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-chcp 65001 >nul
+chcp 1250 >nul
 
 IF EXIST "%~dp0"..\exec.bat (
    del /F /Q "%~dp0"..\exec.bat >nul

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -47,14 +47,27 @@ Sub PrintHelp(cmd, exitCode)
 End Sub
 
 Sub ExecCommand(str)
-    With CreateObject("ADODB.Stream")
+    Dim utfStream
+    Dim outStream
+    Set utfStream = CreateObject("ADODB.Stream")
+    Set outStream = CreateObject("ADODB.Stream")
+    With utfStream
         .CharSet = "utf-8"
+        .Mode = 3 ' adModeReadWrite
         .Open
-        .WriteText("chcp 65001 > NUL" & vbCrLf)
+        .WriteText("chcp 1250 > NUL" & vbCrLf)
         .WriteText(str & vbCrLf)
+        .Position = 3
+    End With
+    With outStream
+        .Type = 1 ' adTypeBinary
+        .Mode = 3 ' adModeReadWrite
+        .Open
+        utfStream.CopyTo outStream
         .SaveToFile strPyenvHome & "\exec.bat", 2
         .Close
     End With
+    utfStream.Close
 End Sub
 
 Function getCommandOutput(theCommand)
@@ -302,13 +315,13 @@ Sub CommandExecute(arg)
     dstr = GetBinDir(GetCurrentVersion()(0))
     str = "set PATH="& dstr &";%PATH:&=^&%"& vbCrLf
     If arg.Count > 1 Then
-      str = str &""""& dstr &"\"& arg(1) &""""
-      Dim idx
-      If arg.Count > 2 Then  
-        For idx = 2 To arg.Count - 1
-          str = str &" """& arg(idx) &""""
-        Next
-      End If
+        str = str &""""& dstr &"\"& arg(1) &""""
+        Dim idx
+        If arg.Count > 2 Then
+            For idx = 2 To arg.Count - 1
+                str = str &" """& arg(idx) &""""
+            Next
+        End If
     End If
     ExecCommand(str)
 End Sub


### PR DESCRIPTION
This PR follows in line after #87 as the 2nd feature PR because of issues I was having after #87 and using pip on Python2 under code page 65001. It looks like according to this [Python issue](https://bugs.python.org/issue6058#msg120712) there's no planned support for cp65001 in Python2 which means to support the special upper ANSI characters that @harvimt mentioned in #51, cp1250 would have to be set, which caused no problem running pip on my system with Python2 and still should show the character(s) they wanted but would prefer if others could test this that have other languages on their systems.

Also noted, I'm not sure if UTF-8 even is fully supported [yet in the Windows 10 Console](https://devblogs.microsoft.com/commandline/windows-command-line-unicode-and-utf-8-output-text-buffer/) but to remain backwards compatible with Python2 (which is still needed on Windows for NodeJS and node-gyp) this should keep it from breaking.

I also rewrote the content of the shims written by "rehash" to no longer use `pyenv exec` in order to prevent other issues from happening that were caused by uncorrectable quoting when writing `exec.bat`.