### PR TITLE
fix exec

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -1,16 +1,74 @@
 @echo off
-setlocal enableDelayedExpansion
-chcp 1250 >nul
+setlocal
+chcp 65001 >nul
 
-IF EXIST "%~dp0"..\exec.bat (
-   del /F /Q "%~dp0"..\exec.bat >nul
+set "pyenv=cscript //nologo "%~dp0"..\libexec\pyenv.vbs"
+
+rem if not the 'exec' command then just call pyenv.vbs directly and exit
+if /i not [%1]==[exec] (
+  %pyenv% %*
+  exit /b
 )
 
-call cscript //nologo "%~dp0"..\libexec\pyenv.vbs %*
-IF EXIST "%~dp0"..\exec.bat (
-   call "%~dp0"..\exec.bat
+if /i [%2]==[--help] (
+  echo Usage: pyenv exec ^<command^> [arg1 arg2...]
+  echo.
+  echo Runs an executable by first preparing PATH so that the selected Python
+  echo version's `bin' directory is at the front.
+  echo.
+  echo For example, if the currently selected Python version is 3.5.3:
+  echo   pyenv exec pip install -r requirements.txt
+  echo.
+  echo is equivalent to:
+  echo   PATH="$PYENV_ROOT/versions/3.5.3/bin:$PATH" pip install -r requirements.txt
+  echo.
+  exit /b
 )
-for /f "tokens=1 delims=|" %%A in (""!PYENV_VERSION!"") do (
-   endLocal
-   set "PYENV_VERSION=%%~A"
+
+rem handle 'exec' command.
+rem 'exec' is enhanced such that now any program can be launched using it.
+rem it ensures that PATH is prefixed so 'current' version of python will
+rem be used by the program passed to 'exec', should it use python itself
+
+rem use pyenv.vbs to aid resolving absolute path (as 'bindir') to 'current' version
+rem and then prepend it to PATH
+for /f %%i in ('%pyenv% version') do call :normalizepath "%~dp0..\versions\%%i" bindir
+set "path=%bindir%;%bindir%\Scripts;%path%"
+
+rem pyenv's shim for 'pip' (pip.bat) calls "pyenv exec Scripts/pip"
+rem but its shim for 'python' calls 'pyenv exec python'.
+rem in the first case we need to deal with the '/' being used,
+rem and that because of 'Scripts', we must launch with absolute path
+rem whereas in the later case we can launch with only the program name (python)
+rem relying on PATH to result in Windows correctly locating it (which
+rem is how we can now launch any program using 'pyenv exec')
+
+for /f "tokens=1,2 delims=/" %%i in ("%2") do set "exepath=%%i" & set "exe=%%j"
+if [%exe%]==[] (set "exe=%exepath%") else (set "exe=%bindir%\%exepath%\%exe%")
+
+rem 'exe' will be either like "C:\<pyenvhome>\versions\<version>\Scripts\pip"
+rem or simply like "python" (or 'dir' when 'pyenv exec dir' called, for ex)
+
+rem copy params to program precisely, preserving double-quotes and percents.
+rem this is the main fix for how 'exec' processing in pyenv.vbs did not
+rem correctly handle (get passed) params with percent chars in them
+:loop
+if not [%3]==[] (
+  set params=%params% %3
+  shift
+  goto loop
 )
+
+rem 'exe' could be a '.bat' file (or any ext in pathext), in which case
+rem it must be launched using 'cmd' to ensure '~dpn' is correct when used
+rem within the '.bat' file. also, calling here fixes concurrency problem
+rem created by the 'exec.bat' approach pyenv.vbs uses
+cmd /c %exe% %params%
+exit /b
+
+rem ----
+rem convert path which may have relative nodes (.. or .)
+rem to its absolute value so can be used in PATH
+:normalizepath
+set "%~2=%~dpf1"
+exit /b

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -11,6 +11,7 @@ if [%1]==[] (
 )
 
 rem use pyenv.vbs to aid resolving absolute path of "active" version into 'bindir'
+set "bindir="
 for /f %%i in ('%pyenv% version') do call :normalizepath "%~dp0..\versions\%%i" bindir
 
 rem all help implemented as plugin
@@ -32,6 +33,11 @@ if /i not [%1]==[exec] goto :plugin
 rem ====================================================================================
 :exec
 
+echo %bindir%
+if not exist "%bindir%" (
+	echo No global python version has been set yet. Please set the global version.
+)
+
 shift
 
 for /f "tokens=1,2 delims=/" %%i in ("%1") do set "exepath=%%i" & set "exe=%%j"
@@ -50,6 +56,9 @@ call :normalizepath %exe% exe
 
 if exist "%exe%.bat" (
   set "exe=endlocal & call "%exe%.bat""
+
+) else if exist "%exe.cmd%" (
+	set "exe=call "%exe%.cmd""
 
 ) else if exist "%exe%.vbs" (
   set "exe=cscript //nologo "%exe%.vbs""
@@ -70,6 +79,7 @@ set "path=%bindir%;%bindir%\Scripts;%path%"
 rem copy params to program precisely, preserving double-quotes and percents.
 rem this is the main fix for how 'exec' processing in pyenv.vbs did not
 rem correctly handle (get passed) params with percent chars in them
+set "params="
 :paramloop
 if not [%2]==[] (
   set params=%params% %2

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -2,7 +2,7 @@
 setlocal
 chcp 1250 >nul
 
-set "pyenv=cscript //nologo "%~dp0"..\libexec\pyenv.vbs"
+set "pyenv=cscript //nologo "%~dp0..\libexec\pyenv.vbs""
 
 rem if 'pyenv' called alone, then run pyenv.vbs
 if [%1]==[] (
@@ -36,7 +36,7 @@ shift
 
 for /f "tokens=1,2 delims=/" %%i in ("%1") do set "exepath=%%i" & set "exe=%%j"
 if [%exe%]==[] (set "exe=%exepath%") else (set "exe=%bindir%\%exepath%\%exe%")
-set "exe=cmd /c %exe%"
+set "exe=cmd /c "%exe%""
 goto :run
 
 
@@ -49,10 +49,10 @@ set "exe=%~dp0..\libexec\pyenv-%1"
 call :normalizepath %exe% exe
 
 if exist "%exe%.bat" (
-  set "exe=endlocal & call %exe%.bat"
+  set "exe=endlocal & call "%exe%.bat""
 
 ) else if exist "%exe%.vbs" (
-  set "exe=cscript //nologo %exe%.vbs"
+  set "exe=cscript //nologo "%exe%.vbs""
 
 ) else (
   echo pyenv: no such command '%1'

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -35,7 +35,7 @@ rem ============================================================================
 
 echo %bindir%
 if not exist "%bindir%" (
-	echo No global python version has been set yet. Please set the global version.
+  echo No global python version has been set yet. Please set the global version.
 )
 
 shift
@@ -58,7 +58,7 @@ if exist "%exe%.bat" (
   set "exe=endlocal & call "%exe%.bat""
 
 ) else if exist "%exe.cmd%" (
-	set "exe=call "%exe%.cmd""
+  set "exe=call "%exe%.cmd""
 
 ) else if exist "%exe%.vbs" (
   set "exe=cscript //nologo "%exe%.vbs""

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -33,9 +33,9 @@ if /i not [%1]==[exec] goto :plugin
 rem ====================================================================================
 :exec
 
-echo %bindir%
 if not exist "%bindir%" (
   echo No global python version has been set yet. Please set the global version.
+  exit /b
 )
 
 shift
@@ -82,7 +82,7 @@ rem correctly handle (get passed) params with percent chars in them
 set "params="
 :paramloop
 if not [%2]==[] (
-  set params=%params% %2
+  set "params=%params% %2"
   shift
   goto paramloop
 )

--- a/pyenv-win/libexec/pyenv-shell.bat
+++ b/pyenv-win/libexec/pyenv-shell.bat
@@ -27,6 +27,6 @@ if [%1]==[] (
 
 ) else (
   echo pyenv specific python requisite didn't meet. Project is using different version of python.
-  echo Install python %1 by typing: 'pyenv install %1'
+  echo Install python '%1' by typing: 'pyenv install %1'
 )
 

--- a/pyenv-win/libexec/pyenv-shell.bat
+++ b/pyenv-win/libexec/pyenv-shell.bat
@@ -1,15 +1,32 @@
 @echo off
-setlocal
 
 if "%1" == "--help" (
-echo Usage: pyenv shell ^<version^>
-echo        pyenv shell --unset
-echo.
-echo Sets a shell-specific Python version by setting the `PYENV_VERSION'
-echo environment variable in your shell. This version overrides local
-echo application-specific versions and the global version.
-echo.
-EXIT /B
+  echo Usage: pyenv shell ^<version^>
+  echo        pyenv shell --unset
+  echo.
+  echo Sets a shell-specific Python version by setting the `PYENV_VERSION'
+  echo environment variable in your shell. This version overrides local
+  echo application-specific versions and the global version.
+  echo.
+  EXIT /B
 )
 
-:: Implementation of this command is in the pyenv.vbs file
+
+if [%1]==[] (
+  if [%PYENV_VERSION%]==[] (
+    echo no shell-specific version configured
+  ) else (
+    echo %PYENV_VERSION%
+  )
+
+) else if /i [%1]==[--unset] (
+  set "PYENV_VERSION="
+
+) else if exist "%~dp0..\versions\%1" (
+  set "PYENV_VERSION=%1"
+
+) else (
+  echo pyenv specific python requisite didn't meet. Project is using different version of python.
+  echo Install python %1 by typing: 'pyenv install %1'
+)
+

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -1,617 +1,485 @@
 Option Explicit
 
+Dim objws
+Dim objfs
 Dim objCmdExec
+Set objws = WScript.CreateObject("WScript.Shell")
+Set objfs = CreateObject("Scripting.FileSystemObject")
 
-' WScript.echo "kkotari: pyenv.vbs..!"
-' WScript.echo "kkotari: pyenv.vbs Defining Import..!"
-Sub Import(importFile)
-    Dim fso, libFile
-    On Error Resume Next
-    Set fso = CreateObject("Scripting.FileSystemObject")
-    Set libFile = fso.OpenTextFile(fso.getParentFolderName(WScript.ScriptFullName) &"\"& importFile, 1)
-    ExecuteGlobal libFile.ReadAll
-    If Err.number <> 0 Then
-        WScript.Echo "Error importing library """& importFile &"""("& Err.Number &"): "& Err.Description
-        WScript.Quit 1
+Dim strCurrent
+Dim strPyenvHome
+Dim strPyenvParent
+Dim strDirCache
+Dim strDirVers
+Dim strDirLibs
+Dim strDirShims
+Dim strVerFile
+strCurrent   = objfs.GetAbsolutePathName(".")
+strPyenvHome = objfs.getParentFolderName(objfs.getParentFolderName(WScript.ScriptFullName))
+strPyenvParent = objfs.getParentFolderName(strPyenvHome)
+strDirCache  = strPyenvHome & "\install_cache"
+strDirVers   = strPyenvHome & "\versions"
+strDirLibs   = strPyenvHome & "\libexec"
+strDirShims  = strPyenvHome & "\shims"
+strVerFile   = "\.python-version"
+
+Dim help
+
+Function IsVersion(version)
+    Dim re
+    Set re = new regexp
+    re.Pattern = "^[a-zA-Z_0-9-.]+$"
+    IsVersion = re.Test(version)
+End Function
+
+Function GetCurrentVersionGlobal()
+    GetCurrentVersionGlobal = Null
+
+    Dim fname
+    Dim objFile
+    fname = strPyenvHome & "\version"
+    If objfs.FileExists( fname ) Then
+        Set objFile = objfs.OpenTextFile(fname)
+        If objFile.AtEndOfStream <> True Then
+           GetCurrentVersionGlobal = Array(objFile.ReadLine,fname)
+        End If
+        objFile.Close
     End If
-    libFile.Close
-End Sub
+End Function
 
-Import "libs\pyenv-lib.vbs"
-' WScript.echo "kkotari: pyenv.vbs Import called..!"
+Function GetCurrentVersionLocal(path)
+    GetCurrentVersionLocal = Null
+
+    Dim fname
+    Dim objFile
+    Do While path <> ""
+        fname = path & strVerFile
+        If objfs.FileExists( fname ) Then
+            Set objFile = objfs.OpenTextFile(fname)
+            If objFile.AtEndOfStream <> True Then
+               GetCurrentVersionLocal = Array(objFile.ReadLine,fname)
+            End If
+            objFile.Close
+            Exit Function
+        End If
+        path = objfs.getParentFolderName(path)
+    Loop
+End Function
+
+Function GetCurrentVersionShell()
+    GetCurrentVersionShell = Null
+
+    Dim str
+    str=objws.ExpandEnvironmentStrings("%PYENV_VERSION%")
+    If str <> "%PYENV_VERSION%" Then
+        GetCurrentVersionShell = Array(str,"%PYENV_VERSION%")
+    End If
+End Function
+
+Function GetCurrentVersion()
+    Dim str
+    str=GetCurrentVersionShell
+    If IsNull(str) Then str = GetCurrentVersionLocal(strCurrent)
+    If IsNull(str) Then str = GetCurrentVersionGlobal
+    If IsNull(str) Then
+		WScript.echo "No global python version has been set yet. Please set the global version by typing:"
+		WScript.echo "pyenv global 3.7.2"
+		WScript.quit
+	End If
+	GetCurrentVersion = str
+End Function
+
+Function GetCurrentVersionNoError()
+    Dim str
+    str=GetCurrentVersionShell
+    If IsNull(str) Then str = GetCurrentVersionLocal(strCurrent)
+    If IsNull(str) Then str = GetCurrentVersionGlobal
+    GetCurrentVersionNoError = str
+End Function
+
+Function GetBinDir(ver)
+    Dim str
+    str=strDirVers & "\" & ver & "\"
+    If Not(IsVersion(ver) And objfs.FolderExists(str)) Then
+		WScript.echo "pyenv specific python requisite didn't meet. Project is using different version of python."
+		WScript.echo "Install python '"&ver&"' by typing: 'pyenv install "&ver&"'"
+		WScript.quit
+	End If
+    GetBinDir = str
+End Function
 
 Function GetCommandList()
-    ' WScript.echo "kkotari: pyenv.vbs get command list..!"
     Dim cmdList
-    Set cmdList = CreateObject("Scripting.Dictionary")
+    Set cmdList = CreateObject("Scripting.Dictionary")'"System.Collections.SortedList"
 
-    Dim fileRegex
-    Dim exts
-    Set fileRegex = new RegExp
-    Set exts = GetExtensionsNoPeriod(False)
-    fileRegex.Pattern = "pyenv-([a-zA-Z_0-9-]+)\."
+    Dim re
+    Set re = new regexp
+    re.Pattern = "\\pyenv-([a-zA-Z_0-9-]+)\.(bat|vbs)$"
 
     Dim file
-    Dim matches
+    Dim mts
     For Each file In objfs.GetFolder(strDirLibs).Files
-        Set matches = fileRegex.Execute(objfs.GetFileName(file))
-        If matches.Count > 0 And exts.Exists(objfs.GetExtensionName(file)) Then
-             cmdList.Add matches(0).SubMatches(0), file
+        Set mts=re.Execute(file)
+        If mts.Count > 0 Then
+             cmdList.Add mts(0).submatches(0), file
         End If
     Next
 
     Set GetCommandList = cmdList
 End Function
 
-Sub PrintVersion(cmd, exitCode)
-    ' WScript.echo "kkotari: pyenv.vbs print version..!"
-    Dim help
-    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat")
-    WScript.Echo help
-    WScript.Quit exitCode
-End Sub
-
-Sub PrintHelp(cmd, exitCode)
-    ' WScript.echo "kkotari: pyenv.vbs print help..!"
-    Dim help
-    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat --help")
-    WScript.Echo help
-    WScript.Quit exitCode
-End Sub
-
-Sub ExecCommand(str)
-    ' WScript.echo "kkotari: pyenv.vbs exec command..!"
-    Dim utfStream
-    Dim outStream
-    Set utfStream = CreateObject("ADODB.Stream")
-    Set outStream = CreateObject("ADODB.Stream")
-    With utfStream
-        .CharSet = "utf-8"
-        .Mode = 3 ' adModeReadWrite
-        .Open
-        .WriteText("chcp 1250 > NUL" & vbCrLf)
-        .WriteText(str & vbCrLf)
-        .Position = 3
-    End With
-    With outStream
-        .Type = 1 ' adTypeBinary
-        .Mode = 3 ' adModeReadWrite
-        .Open
-        utfStream.CopyTo outStream
-        .SaveToFile strPyenvHome & "\exec.bat", 2
-        .Close
-    End With
-    utfStream.Close
+Sub ExecCommand(cmd)
+    Dim oExec
+    Set oExec = objws.exec(cmd)
+    WScript.StdOut.Write oExec.StdOut.ReadAll
+    WScript.StdErr.Write oExec.StdErr.ReadAll
 End Sub
 
 Function getCommandOutput(theCommand)
-    ' WScript.echo "kkotari: pyenv.vbs get command output..!"
     Set objCmdExec = objws.exec(thecommand)
     getCommandOutput = objCmdExec.StdOut.ReadAll
 end Function
 
 Sub CommandShims(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command shims..!"
      Dim shims_files
-     If arg.Count < 2 Then
-     ' WScript.Echo join(arg.ToArray(), ", ")
+     If arg.Count < 2 then
+     ' WScript.echo join(arg.ToArray(), ", ")
      ' if --short passed then remove /s from cmd
-        shims_files = getCommandOutput("cmd /c dir "& strDirShims &"/s /b")
-     ElseIf arg(1) = "--short" Then
-        shims_files = getCommandOutput("cmd /c dir "& strDirShims &" /b")
+        shims_files = getCommandOutput("cmd /c dir "&strDirShims&"/s /b")
+     ElseIf arg(1) = "--short" then
+        shims_files = getCommandOutput("cmd /c dir "&strDirShims&" /b")
      Else
-        shims_files = getCommandOutput("cmd /c "& strDirLibs &"\pyenv-shims.bat --help")
+        shims_files = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shims.bat --help")
      End IF
-     WScript.Echo shims_files
+     WScript.echo shims_files
 End Sub
 
-' NOTE: Exists because of its possible reuse from the original Linux pyenv.
-'Function RemoveFromPath(pathToRemove)
-'    Dim path_before
-'    Dim result
-
-'    result = objws.Environment("Process")("PATH")
-'    If Left(result, 1) <> ";" Then result = ";"&result
-'    If Right(result, 1) <> ";" Then result = result&";"
-
-'    Do While path_before <> result
-'        path_before = result
-'        result = Replace(result, ";"& pathToRemove &";", ";")
-'    Loop
-
-'    RemoveFromPath = Mid(result, 2, Len(result)-2)
-'End Function
-
 Sub CommandWhich(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command which..!"
-    If arg.Count < 2 Then
-        PrintHelp "pyenv-which", 1
-    ElseIf arg(1) = "--help" Or arg(1) = "" Then
-        PrintHelp "pyenv-which", Abs(arg(1) = "")
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-which.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
-    Dim path
-    Dim program
-    Dim exts
-    Dim ext
-    Dim version
-
-    program = arg(1)
-    If program = "" Then PrintHelp "pyenv-which", 1
-    If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
-
-    Set exts = GetExtensions(True)
-
-    Dim versions
-    Set versions = GetCurrentVersions
-    For Each version In versions
-
-        If Not objfs.FolderExists(strDirVers &"\"& version) Then
-            WScript.Echo "pyenv: version `"& version &"' is not installed (set by "& version &")"
-            WScript.Quit 1
-        End If
-
-        If objfs.FileExists(strDirVers &"\"& version &"\"& program) Then
-            WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\"& program).Path
-            WScript.Quit 0
-        End If
-
-        For Each ext In exts.Keys
-            If objfs.FileExists(strDirVers &"\"& version &"\"& program & ext) Then
-                WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\"& program & ext).Path
-                WScript.Quit 0
-            End If
-        Next
-
-        If objfs.FolderExists(strDirVers &"\"& version & "\Scripts") Then
-            If objfs.FileExists(strDirVers &"\"& version &"\Scripts\"& program) Then
-                WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\Scripts\"& program).Path
-                WScript.Quit 0
-            End If
-
-            For Each ext In exts.Keys
-                If objfs.FileExists(strDirVers &"\"& version &"\Scripts\"& program & ext) Then
-                    WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\Scripts\"& program & ext).Path
-                    WScript.Quit 0
-                End If
-            Next
-        End If
-    Next
-
-    WScript.Echo "pyenv: "& arg(1) &": command not found"
-
-    version = getCommandOutput("cscript //Nologo "& WScript.ScriptFullName &" whence "& program)
-    If Trim(version) <> "" Then
-        WScript.Echo
-        WScript.Echo "The '"& arg(1) &"' command exists in these Python versions:"
-        WScript.Echo "  "& Replace(version, vbCrLf, vbCrLf &"  ")
-    End If
-
-    WScript.Quit 127
+     WScript.echo "TO be added"
 End Sub
 
 Sub CommandWhence(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command whence..!"
-    If arg.Count < 2 Then
-        PrintHelp "pyenv-whence", 1
-    ElseIf arg(1) = "--help" Or arg(1) = "" Then
-        PrintHelp "pyenv-whence", Abs(arg(1) = "")
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-whence.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
-    Dim program
-    Dim exts
-    Dim ext
-    dim path
-    Dim dir
-    Dim isPath
-    Dim found
-    Dim foundAny ' Acts as an exit code: 0=Success, 1=No files/versions found
-
-    If arg(1) = "--path" Then
-        If arg.Count < 3 Then PrintHelp "pyenv-whence", 1
-        isPath = True
-        program = arg(2)
-    Else
-        program = arg(1)
-    End If
-
-    If program = "" Then PrintHelp "pyenv-whence", 1
-    If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
-
-    Set exts = GetExtensions(True)
-    foundAny = 1
-
-    For Each dir In objfs.GetFolder(strDirVers).subfolders
-        found = False
-
-        If objfs.FileExists(dir & "\" & program) Then
-            found = True
-            foundAny = 0
-            If isPath Then
-                WScript.Echo objfs.GetFile(dir & "\" & program).Path
-            Else
-                WScript.Echo objfs.GetFileName( dir )
-            End If
-        End If
-
-        If Not found Or isPath Then
-            For Each ext In exts.Keys
-                If objfs.FileExists(dir & "\" & program & ext) Then
-                    found = True
-                    foundAny = 0
-                    If isPath Then
-                        WScript.Echo objfs.GetFile(dir & "\" & program & ext).Path
-                    Else
-                        WScript.Echo objfs.GetFileName( dir )
-                    End If
-                    Exit For
-                End If
-            Next
-        End If
-
-        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
-            If objfs.FileExists(dir & "\Scripts\" & program) Then
-                found = True
-                foundAny = 0
-                If isPath Then
-                    WScript.Echo objfs.GetFile(dir & "\Scripts\" & program).Path
-                Else
-                    WScript.Echo objfs.GetFileName( dir )
-                End If
-            End If
-        End If
-
-        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
-            For Each ext In exts.Keys
-                If objfs.FileExists(dir & "\Scripts\" & program & ext) Then
-                    foundAny = 0
-                    If isPath Then
-                        WScript.Echo objfs.GetFile(dir & "\Scripts\" & program & ext).Path
-                    Else
-                        WScript.Echo objfs.GetFileName( dir )
-                    End If
-                    Exit For
-                End If
-            Next
-        End If
-    Next
-
-    WScript.Quit foundAny
+     WScript.echo "TO be added"
 End Sub
 
 Sub ShowHelp()
-    '  WScript.echo "kkotari: pyenv.vbs show help..!"
-     WScript.Echo "pyenv " & objfs.OpenTextFile(strPyenvParent & "\.version").ReadAll
-     WScript.Echo "Usage: pyenv <command> [<args>]"
-     WScript.Echo ""
-     WScript.Echo "Some useful pyenv commands are:"
-     WScript.Echo "   commands     List all available pyenv commands"
-     WScript.Echo "   duplicate    Creates a duplicate python environment"
-     WScript.Echo "   local        Set or show the local application-specific Python version"
-     WScript.Echo "   global       Set or show the global Python version"
-     WScript.Echo "   shell        Set or show the shell-specific Python version"
-     WScript.Echo "   install      Install a Python version using python-build"
-     WScript.Echo "   uninstall    Uninstall a specific Python version"
-     WScript.Echo "   update       Update the cached version DB"
-     WScript.echo "   rehash       Rehash pyenv shims (run this after installing executables)"
-     WScript.Echo "   vname        Show the current Python version"
-     WScript.Echo "   version      Show the current Python version and its origin"
-     WScript.Echo "   version-name Show the current Python version"
-     WScript.Echo "   versions     List all Python versions available to pyenv"
-     WScript.Echo "   exec         Runs an executable by first preparing PATH so that the selected Python"
-     WScript.Echo "   which        Display the full path to an executable"
-     WScript.Echo "   whence       List all Python versions that contain the given executable"
-     WScript.Echo ""
-     WScript.Echo "See `pyenv help <command>' for information on a specific command."
-     WScript.Echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
-End Sub
-
-Sub CommandScriptVersion(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command script version..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv---version", 0
-    End If
-
-    If arg.Count = 1 Then
-        Dim list
-        Set list = GetCommandList
-        If list.Exists(arg(0)) Then
-            PrintVersion "pyenv---version", 0
-        Else
-             WScript.Echo "unknown pyenv command '"& arg(0) &"'"
-        End If
-    Else
-        ShowHelp
-    End If
+     WScript.echo "pyenv " & objfs.OpenTextFile(strPyenvParent & "\.version").ReadAll
+     WScript.echo "Usage: pyenv <command> [<args>]"
+     WScript.echo ""
+     WScript.echo "Some useful pyenv commands are:"
+     WScript.echo "   commands    List all available pyenv commands"
+     WScript.echo "   duplicate   Creates a duplicate python environment"
+     WScript.echo "   local       Set or show the local application-specific Python version"
+     WScript.echo "   global      Set or show the global Python version"
+     WScript.echo "   shell       Set or show the shell-specific Python version"
+     WScript.echo "   install     Install a Python version using python-build"
+     WScript.echo "   uninstall   Uninstall a specific Python version"
+     WScript.echo "   rehash      Rehash pyenv shims (run this after installing executables)"
+     WScript.echo "   version     Show the current Python version and its origin"
+     WScript.echo "   versions    List all Python versions available to pyenv"
+     WScript.echo "   exec        Runs an executable by first preparing PATH so that the selected Python"
+     WScript.echo "   which       Display the full path to an executable"
+     WScript.echo "   whence      List all Python versions that contain the given executable"
+     WScript.echo ""
+     WScript.echo "See `pyenv help <command>' for information on a specific command."
+     WScript.echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
 End Sub
 
 Sub CommandHelp(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command help..!"
     If arg.Count > 1 Then
         Dim list
-        Set list = GetCommandList
+        Set list=GetCommandList
         If list.Exists(arg(1)) Then
             ExecCommand(list(arg(1)) & " --help")
         Else
-             WScript.Echo "unknown pyenv command '"& arg(1) &"'"
+             WScript.echo "unknown pyenv command '"&arg(1)&"'"
         End If
     Else
         ShowHelp
     End If
 End Sub
 
+
 Sub CommandRehash(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command rehash..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-rehash", 0
-    End If
-
-    Rehash
-End Sub
-
-Sub CommandExecute(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command exec..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-exec", 0
-    End If
-
-    Dim str
-    Dim dstr
-    dstr = GetBinDir(GetCurrentVersion()(0))
-    str = "set PATH="& dstr &";%PATH:&=^&%"& vbCrLf
-    If arg.Count > 1 Then
-        str = str &""""& dstr &"\"& arg(1) &""""
-        Dim idx
-        If arg.Count > 2 Then
-            For idx = 2 To arg.Count - 1
-                str = str &" """& arg(idx) &""""
-            Next
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-rehash.bat --help")
+            WScript.echo help
+            Exit Sub
         End If
     End If
-    ExecCommand(str)
+
+    Dim strDirShims
+    strDirShims= strPyenvHome & "\shims"
+    If Not objfs.FolderExists( strDirShims ) Then objfs.CreateFolder(strDirShims)
+
+    Dim ofile
+    Dim file
+    For Each file In objfs.GetFolder(strDirShims).Files
+        objfs.DeleteFile file, True
+    Next
+
+    For Each file In objfs.GetFolder(GetBinDir(GetCurrentVersion()(0))).Files
+        If objfs.GetExtensionName(file) = "exe" or objfs.GetExtensionName(file) = "bat" or objfs.GetExtensionName(file) = "cmd" or objfs.GetExtensionName(file) = "py" Then
+          Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) & ".bat" )
+          ofile.WriteLine("@echo off")
+          ofile.WriteLine("pyenv exec %~n0 %*")
+          ofile.Close()
+          Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) )
+          ofile.WriteLine("#!/bin/sh")
+          ofile.WriteLine("pyenv exec $(basename ""$0"") $*")
+          ofile.Close()
+        End If
+    Next
+
+    If objfs.FolderExists(GetBinDir(GetCurrentVersion()(0)) & "\Scripts") Then
+        For Each file In objfs.GetFolder(GetBinDir(GetCurrentVersion()(0)) & "\Scripts").Files
+            If objfs.GetExtensionName(file) = "exe" or objfs.GetExtensionName(file) = "bat" or objfs.GetExtensionName(file) = "cmd" or objfs.GetExtensionName(file) = "py" Then
+            Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) & ".bat" )
+            ofile.WriteLine("@echo off")
+            ofile.WriteLine("pyenv exec Scripts/%~n0 %*")
+            ofile.Close()
+            Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) )
+            ofile.WriteLine("#!/bin/sh")
+            ofile.WriteLine("pyenv exec Scripts/$(basename ""$0"") $*")
+            ofile.Close()
+            End If
+        Next
+    End If
 End Sub
 
 Sub CommandGlobal(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command global..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-global", 0
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-global.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
-    Dim ver
     If arg.Count < 2 Then
-        ver = GetCurrentVersionGlobal()
+        Dim ver
+        ver=GetCurrentVersionGlobal()
         If IsNull(ver) Then
-            WScript.Echo "no global version configured"
+            WScript.echo "no global version configured"
         Else
-            WScript.Echo ver(0)
+            WScript.echo ver(0)
         End If
     Else
-        If arg(1) = "--unset" Then
-            ver = ""
-            objfs.DeleteFile strPyenvHome &"\version", True
-            Exit Sub
-        Else
-            ver = Check32Bit(arg(1))
-            SetGlobalVersion ver
-        End If
+        GetBinDir(arg(1))
+        Dim ofile
+        Set ofile = objfs.CreateTextFile( strPyenvHome & "\version" , True )
+        ofile.WriteLine(arg(1))
+        ofile.Close()
     End If
 End Sub
 
 Sub CommandLocal(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command local..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-local", 0
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-local.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
     Dim ver
     If arg.Count < 2 Then
-        Dim currentVersions
-        currentVersions = GetCurrentVersionsLocal(strCurrent)
-        If IsNull(currentVersions) Then
-            WScript.Echo "no local version configured for this directory"
+        ver=GetCurrentVersionLocal(strCurrent)
+        If IsNull(ver) Then
+            WScript.echo "no local version configured for this directory"
         Else
-            For Each ver in currentVersions
-                WScript.Echo ver(0)
-            Next
+            WScript.echo ver(0)
         End If
     Else
-        If arg(1) = "--unset" Then
+        ver=arg(1)
+        If ver = "--unset" Then
             ver = ""
             objfs.DeleteFile strCurrent & strVerFile, True
             Exit Sub
         Else
-            Dim versionCount
-            versionCount = arg.Count - 1
-            ReDim localVersions(versionCount - 1)
-            Dim i
-            For i = 0 To versionCount - 1
-                localVersions(i) = Check32Bit(arg(i + 1))
-                GetBinDir(localVersions(i))
-            Next
+            GetBinDir(ver)
         End If
-
         Dim ofile
         If objfs.FileExists(strCurrent & strVerFile) Then
-            Set ofile = objfs.OpenTextFile(strCurrent & strVerFile, 2)
+          Set ofile = objfs.OpenTextFile ( strCurrent & strVerFile , 2 )
         Else
-            Set ofile = objfs.CreateTextFile(strCurrent & strVerFile, True)
+          Set ofile = objfs.CreateTextFile( strCurrent & strVerFile , True )
         End If
-        For Each ver in localVersions
-            ofile.WriteLine(ver)
-        Next
+        ofile.WriteLine(ver)
         ofile.Close()
     End If
 End Sub
 
 Sub CommandShell(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command shell..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-shell", 0
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shell.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
     Dim ver
     If arg.Count < 2 Then
-        ver = GetCurrentVersionShell
+        ver=GetCurrentVersionShell
         If IsNull(ver) Then
-            WScript.Echo "no shell-specific version configured"
+            WScript.echo "no shell-specific version configured"
         Else
-            WScript.Echo ver(0)
+            WScript.echo ver(0)
         End If
     Else
-        If arg(1) = "--unset" Then
+        ver=arg(1)
+        If ver = "--unset" Then
             ver = ""
         Else
-            ver = Check32Bit(arg(1))
             GetBinDir(ver)
         End If
-        ExecCommand("set PYENV_VERSION="& ver)
+        ExecCommand("endlocal && set PYENV_VERSION=" & ver)
     End If
 End Sub
 
 Sub CommandVersion(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command version..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-version", 0
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-version.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
-    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
+    If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
 
     Dim curVer
-    Dim versions
-    Set versions = GetCurrentVersions
-    For Each curVer In versions
-        WScript.Echo curVer &" (set by "& versions(curVer) &")"
-    Next
-End Sub
-
-Sub CommandVersionName(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command version-name..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-version-name", 0
-    End If
-
-    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
-
-    Dim ver, versions
-    Set versions = GetCurrentVersions
-    For Each ver in versions
-        WScript.Echo ver
-    Next
-End Sub
-
-Sub CommandVersionNameShort(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command vname..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-vname", 0
-    End If
-
-    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
-
-    Dim ver, versions
-    Set versions = GetCurrentVersions
-    For Each ver in versions
-        WScript.Echo ver
-    Next
+    curVer=GetCurrentVersion
+    WScript.echo curVer(0) & " (set by " &curVer(1)&")"
 End Sub
 
 Sub CommandVersions(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command versions..!"
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-versions", 0
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-versions.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
     Dim isBare
-    isBare = False
+    isBare=False
     If arg.Count >= 2 Then
-        If arg(1) = "--bare" Then isBare = True
+        If arg(1) = "--bare" Then isBare=True
     End If
 
-    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
+    If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
 
-    Dim versions
-    Set versions = GetCurrentVersionsNoError
+    Dim curVer
+    curVer=GetCurrentVersionNoError
+    If IsNull(curVer) Then
+        curVer=Array("","")
+    End If
 
     Dim dir
     Dim ver
     For Each dir In objfs.GetFolder(strDirVers).subfolders
-        ver = objfs.GetFileName(dir)
+        ver=objfs.GetFileName( dir )
         If isBare Then
-            WScript.Echo ver
-        ElseIf versions.Exists(ver) Then
-            WScript.Echo "* "& ver &" (set by "& versions(ver) &")"
+            WScript.echo ver
+        ElseIf ver = curVer(0) Then
+            WScript.echo "* " & ver & " (set by " &curVer(1)&")"
         Else
-            WScript.Echo "  "& ver
+            WScript.echo "  " & ver
         End If
     Next
 End Sub
 
 Sub PlugIn(arg)
-    ' WScript.echo "kkotari: pyenv.vbs plugin..!"
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-"&arg(0)&".bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
+    End If
 
     Dim fname
     Dim idx
     Dim str
-    fname = strDirLibs &"\pyenv-"& arg(0)
-    If objfs.FileExists(fname &".bat" ) Then
-        str = """"& fname &".bat"""
-    ElseIf objfs.FileExists(fname &".vbs" ) Then
-        str = "cscript //nologo """& fname &".vbs"""
+    fname = strDirLibs & "\pyenv-" & arg(0)
+    If objfs.FileExists( fname & ".bat" ) Then
+        str="""" & fname & ".bat"""
+    ElseIf objfs.FileExists( fname & ".vbs" ) Then
+        str="cscript //nologo """ & fname & ".vbs"""
     Else
-       WScript.Echo "pyenv: no such command `"& arg(0) &"'"
+       WScript.echo "pyenv: no such command `"&arg(0)&"'"
        WScript.Quit
     End If
 
     For idx = 1 To arg.Count - 1
-      str = str &" """& arg(idx) &""""
+      str=str & " """& arg(idx) &""""
     Next
 
     ExecCommand(str)
 End Sub
 
 Sub CommandCommands(arg)
-    ' WScript.echo "kkotari: pyenv.vbs command commands..!"
     Dim cname
 
-    If arg.Count >= 2 Then
-        If arg(1) = "--help" Then PrintHelp "pyenv-commands", 0
+    If arg.Count >= 2 then
+        If arg(1) = "--help" then
+            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-commands.bat --help")
+            WScript.echo help
+            Exit Sub
+        End If
     End If
 
     For Each cname In GetCommandList()
-        WScript.Echo cname
+        WScript.echo cname
     Next
 End Sub
 
 Sub Dummy()
-     WScript.Echo "command not implement"
+     WScript.echo "command not implement"
 End Sub
 
 
 Sub main(arg)
-    ' WScript.echo "kkotari: pyenv.vbs main..!"
-    ' WScript.echo "kkotari: "&arg(0)
     If arg.Count = 0 Then
         ShowHelp
     Else
         Select Case arg(0)
-           Case "--version"    CommandScriptVersion(arg)
-           Case "exec"         CommandExecute(arg)
-           Case "rehash"       CommandRehash(arg)
-           Case "global"       CommandGlobal(arg)
-           Case "local"        CommandLocal(arg)
-           Case "shell"        CommandShell(arg)
-           Case "version"      CommandVersion(arg)
-           Case "vname"        CommandVersionNameShort(arg)
-           Case "version-name" CommandVersionName(arg)
-           Case "versions"     CommandVersions(arg)
-           Case "commands"     CommandCommands(arg)
-           Case "shims"        CommandShims(arg)
-           Case "which"        CommandWhich(arg)
-           Case "whence"       CommandWhence(arg)
-           Case "help"         CommandHelp(arg)
-           Case "--help"       CommandHelp(arg)
-           Case Else           PlugIn(arg)
+           Case "rehash"      CommandRehash(arg)
+           Case "global"      CommandGlobal(arg)
+           Case "local"       CommandLocal(arg)
+           Case "shell"       CommandShell(arg)
+           Case "version"     CommandVersion(arg)
+           Case "versions"    CommandVersions(arg)
+           Case "commands"    CommandCommands(arg)
+           Case "shims"       CommandShims(arg)
+           Case "which"       CommandWhich(arg)
+           Case "whence"      CommandWhence(arg)
+           Case "help"        CommandHelp(arg)
+           Case "--help"      CommandHelp(arg)
+           Case Else          PlugIn(arg)
         End Select
     End If
 End Sub
+
+
 
 main(WScript.Arguments)

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -1,485 +1,492 @@
 Option Explicit
 
-Dim objws
-Dim objfs
 Dim objCmdExec
-Set objws = WScript.CreateObject("WScript.Shell")
-Set objfs = CreateObject("Scripting.FileSystemObject")
 
-Dim strCurrent
-Dim strPyenvHome
-Dim strPyenvParent
-Dim strDirCache
-Dim strDirVers
-Dim strDirLibs
-Dim strDirShims
-Dim strVerFile
-strCurrent   = objfs.GetAbsolutePathName(".")
-strPyenvHome = objfs.getParentFolderName(objfs.getParentFolderName(WScript.ScriptFullName))
-strPyenvParent = objfs.getParentFolderName(strPyenvHome)
-strDirCache  = strPyenvHome & "\install_cache"
-strDirVers   = strPyenvHome & "\versions"
-strDirLibs   = strPyenvHome & "\libexec"
-strDirShims  = strPyenvHome & "\shims"
-strVerFile   = "\.python-version"
-
-Dim help
-
-Function IsVersion(version)
-    Dim re
-    Set re = new regexp
-    re.Pattern = "^[a-zA-Z_0-9-.]+$"
-    IsVersion = re.Test(version)
-End Function
-
-Function GetCurrentVersionGlobal()
-    GetCurrentVersionGlobal = Null
-
-    Dim fname
-    Dim objFile
-    fname = strPyenvHome & "\version"
-    If objfs.FileExists( fname ) Then
-        Set objFile = objfs.OpenTextFile(fname)
-        If objFile.AtEndOfStream <> True Then
-           GetCurrentVersionGlobal = Array(objFile.ReadLine,fname)
-        End If
-        objFile.Close
+' WScript.echo "kkotari: pyenv.vbs..!"
+' WScript.echo "kkotari: pyenv.vbs Defining Import..!"
+Sub Import(importFile)
+    Dim fso, libFile
+    On Error Resume Next
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Set libFile = fso.OpenTextFile(fso.getParentFolderName(WScript.ScriptFullName) &"\"& importFile, 1)
+    ExecuteGlobal libFile.ReadAll
+    If Err.number <> 0 Then
+        WScript.Echo "Error importing library """& importFile &"""("& Err.Number &"): "& Err.Description
+        WScript.Quit 1
     End If
-End Function
+    libFile.Close
+End Sub
 
-Function GetCurrentVersionLocal(path)
-    GetCurrentVersionLocal = Null
-
-    Dim fname
-    Dim objFile
-    Do While path <> ""
-        fname = path & strVerFile
-        If objfs.FileExists( fname ) Then
-            Set objFile = objfs.OpenTextFile(fname)
-            If objFile.AtEndOfStream <> True Then
-               GetCurrentVersionLocal = Array(objFile.ReadLine,fname)
-            End If
-            objFile.Close
-            Exit Function
-        End If
-        path = objfs.getParentFolderName(path)
-    Loop
-End Function
-
-Function GetCurrentVersionShell()
-    GetCurrentVersionShell = Null
-
-    Dim str
-    str=objws.ExpandEnvironmentStrings("%PYENV_VERSION%")
-    If str <> "%PYENV_VERSION%" Then
-        GetCurrentVersionShell = Array(str,"%PYENV_VERSION%")
-    End If
-End Function
-
-Function GetCurrentVersion()
-    Dim str
-    str=GetCurrentVersionShell
-    If IsNull(str) Then str = GetCurrentVersionLocal(strCurrent)
-    If IsNull(str) Then str = GetCurrentVersionGlobal
-    If IsNull(str) Then
-		WScript.echo "No global python version has been set yet. Please set the global version by typing:"
-		WScript.echo "pyenv global 3.7.2"
-		WScript.quit
-	End If
-	GetCurrentVersion = str
-End Function
-
-Function GetCurrentVersionNoError()
-    Dim str
-    str=GetCurrentVersionShell
-    If IsNull(str) Then str = GetCurrentVersionLocal(strCurrent)
-    If IsNull(str) Then str = GetCurrentVersionGlobal
-    GetCurrentVersionNoError = str
-End Function
-
-Function GetBinDir(ver)
-    Dim str
-    str=strDirVers & "\" & ver & "\"
-    If Not(IsVersion(ver) And objfs.FolderExists(str)) Then
-		WScript.echo "pyenv specific python requisite didn't meet. Project is using different version of python."
-		WScript.echo "Install python '"&ver&"' by typing: 'pyenv install "&ver&"'"
-		WScript.quit
-	End If
-    GetBinDir = str
-End Function
+Import "libs\pyenv-lib.vbs"
+' WScript.echo "kkotari: pyenv.vbs Import called..!"
 
 Function GetCommandList()
+    ' WScript.echo "kkotari: pyenv.vbs get command list..!"
     Dim cmdList
-    Set cmdList = CreateObject("Scripting.Dictionary")'"System.Collections.SortedList"
+    Set cmdList = CreateObject("Scripting.Dictionary")
 
-    Dim re
-    Set re = new regexp
-    re.Pattern = "\\pyenv-([a-zA-Z_0-9-]+)\.(bat|vbs)$"
+    Dim fileRegex
+    Dim exts
+    Set fileRegex = new RegExp
+    Set exts = GetExtensionsNoPeriod(False)
+    fileRegex.Pattern = "pyenv-([a-zA-Z_0-9-]+)\."
 
     Dim file
-    Dim mts
+    Dim matches
     For Each file In objfs.GetFolder(strDirLibs).Files
-        Set mts=re.Execute(file)
-        If mts.Count > 0 Then
-             cmdList.Add mts(0).submatches(0), file
+        Set matches = fileRegex.Execute(objfs.GetFileName(file))
+        If matches.Count > 0 And exts.Exists(objfs.GetExtensionName(file)) Then
+             cmdList.Add matches(0).SubMatches(0), file
         End If
     Next
 
     Set GetCommandList = cmdList
 End Function
 
-Sub ExecCommand(cmd)
-    Dim oExec
-    Set oExec = objws.exec(cmd)
-    WScript.StdOut.Write oExec.StdOut.ReadAll
-    WScript.StdErr.Write oExec.StdErr.ReadAll
+Sub PrintVersion(cmd, exitCode)
+    ' WScript.echo "kkotari: pyenv.vbs print version..!"
+    Dim help
+    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat")
+    WScript.Echo help
+    WScript.Quit exitCode
+End Sub
+
+Sub PrintHelp(cmd, exitCode)
+    ' WScript.echo "kkotari: pyenv.vbs print help..!"
+    Dim help
+    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat --help")
+    WScript.Echo help
+    WScript.Quit exitCode
+End Sub
+
+Sub ExecCommand(str)
+    ' WScript.echo "kkotari: pyenv.vbs exec command..!"
+    Dim utfStream
+    Dim outStream
+    Set utfStream = CreateObject("ADODB.Stream")
+    Set outStream = CreateObject("ADODB.Stream")
+    With utfStream
+        .CharSet = "utf-8"
+        .Mode = 3 ' adModeReadWrite
+        .Open
+        .WriteText("chcp 1250 > NUL" & vbCrLf)
+        .WriteText(str & vbCrLf)
+        .Position = 3
+    End With
+    With outStream
+        .Type = 1 ' adTypeBinary
+        .Mode = 3 ' adModeReadWrite
+        .Open
+        utfStream.CopyTo outStream
+        .SaveToFile strPyenvHome & "\exec.bat", 2
+        .Close
+    End With
+    utfStream.Close
 End Sub
 
 Function getCommandOutput(theCommand)
+    ' WScript.echo "kkotari: pyenv.vbs get command output..!"
     Set objCmdExec = objws.exec(thecommand)
     getCommandOutput = objCmdExec.StdOut.ReadAll
 end Function
 
 Sub CommandShims(arg)
+    ' WScript.echo "kkotari: pyenv.vbs command shims..!"
      Dim shims_files
-     If arg.Count < 2 then
-     ' WScript.echo join(arg.ToArray(), ", ")
+     If arg.Count < 2 Then
+     ' WScript.Echo join(arg.ToArray(), ", ")
      ' if --short passed then remove /s from cmd
-        shims_files = getCommandOutput("cmd /c dir "&strDirShims&"/s /b")
-     ElseIf arg(1) = "--short" then
-        shims_files = getCommandOutput("cmd /c dir "&strDirShims&" /b")
+        shims_files = getCommandOutput("cmd /c dir "& strDirShims &"/s /b")
+     ElseIf arg(1) = "--short" Then
+        shims_files = getCommandOutput("cmd /c dir "& strDirShims &" /b")
      Else
-        shims_files = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shims.bat --help")
+        shims_files = getCommandOutput("cmd /c "& strDirLibs &"\pyenv-shims.bat --help")
      End IF
-     WScript.echo shims_files
+     WScript.Echo shims_files
 End Sub
 
+' NOTE: Exists because of its possible reuse from the original Linux pyenv.
+'Function RemoveFromPath(pathToRemove)
+'    Dim path_before
+'    Dim result
+
+'    result = objws.Environment("Process")("PATH")
+'    If Left(result, 1) <> ";" Then result = ";"&result
+'    If Right(result, 1) <> ";" Then result = result&";"
+
+'    Do While path_before <> result
+'        path_before = result
+'        result = Replace(result, ";"& pathToRemove &";", ";")
+'    Loop
+
+'    RemoveFromPath = Mid(result, 2, Len(result)-2)
+'End Function
+
 Sub CommandWhich(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-which.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
+    ' WScript.echo "kkotari: pyenv.vbs command which..!"
+    If arg.Count < 2 or arg(1) = "" Then
+        PrintHelp "pyenv-which", 1
     End If
 
-     WScript.echo "TO be added"
+    Dim path
+    Dim program
+    Dim exts
+    Dim ext
+    Dim version
+
+    program = arg(1)
+    If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
+
+    Set exts = GetExtensions(True)
+
+    Dim versions
+    Set versions = GetCurrentVersions
+    For Each version In versions
+
+        If Not objfs.FolderExists(strDirVers &"\"& version) Then
+            WScript.Echo "pyenv: version `"& version &"' is not installed (set by "& version &")"
+            WScript.Quit 1
+        End If
+
+        If objfs.FileExists(strDirVers &"\"& version &"\"& program) Then
+            WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\"& program).Path
+            WScript.Quit 0
+        End If
+
+        For Each ext In exts.Keys
+            If objfs.FileExists(strDirVers &"\"& version &"\"& program & ext) Then
+                WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\"& program & ext).Path
+                WScript.Quit 0
+            End If
+        Next
+
+        If objfs.FolderExists(strDirVers &"\"& version & "\Scripts") Then
+            If objfs.FileExists(strDirVers &"\"& version &"\Scripts\"& program) Then
+                WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\Scripts\"& program).Path
+                WScript.Quit 0
+            End If
+
+            For Each ext In exts.Keys
+                If objfs.FileExists(strDirVers &"\"& version &"\Scripts\"& program & ext) Then
+                    WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\Scripts\"& program & ext).Path
+                    WScript.Quit 0
+                End If
+            Next
+        End If
+    Next
+
+    WScript.Echo "pyenv: "& arg(1) &": command not found"
+
+    version = getCommandOutput("cscript //Nologo "& WScript.ScriptFullName &" whence "& program)
+    If Trim(version) <> "" Then
+        WScript.Echo
+        WScript.Echo "The '"& arg(1) &"' command exists in these Python versions:"
+        WScript.Echo "  "& Replace(version, vbCrLf, vbCrLf &"  ")
+    End If
+
+    WScript.Quit 127
 End Sub
 
 Sub CommandWhence(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-whence.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
+    ' WScript.echo "kkotari: pyenv.vbs command whence..!"
+    If arg.Count < 2 or arg(1) = "" Then
+        PrintHelp "pyenv-whence", 1
     End If
 
-     WScript.echo "TO be added"
+    Dim program
+    Dim exts
+    Dim ext
+    dim path
+    Dim dir
+    Dim isPath
+    Dim found
+    Dim foundAny ' Acts as an exit code: 0=Success, 1=No files/versions found
+
+    If arg(1) = "--path" Then
+        If arg.Count < 3 Then PrintHelp "pyenv-whence", 1
+        isPath = True
+        program = arg(2)
+    Else
+        program = arg(1)
+    End If
+
+    If program = "" Then PrintHelp "pyenv-whence", 1
+    If Right(program, 1) = "." Then program = Left(program, Len(program)-1)
+
+    Set exts = GetExtensions(True)
+    foundAny = 1
+
+    For Each dir In objfs.GetFolder(strDirVers).subfolders
+        found = False
+
+        If objfs.FileExists(dir & "\" & program) Then
+            found = True
+            foundAny = 0
+            If isPath Then
+                WScript.Echo objfs.GetFile(dir & "\" & program).Path
+            Else
+                WScript.Echo objfs.GetFileName( dir )
+            End If
+        End If
+
+        If Not found Or isPath Then
+            For Each ext In exts.Keys
+                If objfs.FileExists(dir & "\" & program & ext) Then
+                    found = True
+                    foundAny = 0
+                    If isPath Then
+                        WScript.Echo objfs.GetFile(dir & "\" & program & ext).Path
+                    Else
+                        WScript.Echo objfs.GetFileName( dir )
+                    End If
+                    Exit For
+                End If
+            Next
+        End If
+
+        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
+            If objfs.FileExists(dir & "\Scripts\" & program) Then
+                found = True
+                foundAny = 0
+                If isPath Then
+                    WScript.Echo objfs.GetFile(dir & "\Scripts\" & program).Path
+                Else
+                    WScript.Echo objfs.GetFileName( dir )
+                End If
+            End If
+        End If
+
+        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
+            For Each ext In exts.Keys
+                If objfs.FileExists(dir & "\Scripts\" & program & ext) Then
+                    foundAny = 0
+                    If isPath Then
+                        WScript.Echo objfs.GetFile(dir & "\Scripts\" & program & ext).Path
+                    Else
+                        WScript.Echo objfs.GetFileName( dir )
+                    End If
+                    Exit For
+                End If
+            Next
+        End If
+    Next
+
+    WScript.Quit foundAny
 End Sub
 
 Sub ShowHelp()
-     WScript.echo "pyenv " & objfs.OpenTextFile(strPyenvParent & "\.version").ReadAll
-     WScript.echo "Usage: pyenv <command> [<args>]"
-     WScript.echo ""
-     WScript.echo "Some useful pyenv commands are:"
-     WScript.echo "   commands    List all available pyenv commands"
-     WScript.echo "   duplicate   Creates a duplicate python environment"
-     WScript.echo "   local       Set or show the local application-specific Python version"
-     WScript.echo "   global      Set or show the global Python version"
-     WScript.echo "   shell       Set or show the shell-specific Python version"
-     WScript.echo "   install     Install a Python version using python-build"
-     WScript.echo "   uninstall   Uninstall a specific Python version"
-     WScript.echo "   rehash      Rehash pyenv shims (run this after installing executables)"
-     WScript.echo "   version     Show the current Python version and its origin"
-     WScript.echo "   versions    List all Python versions available to pyenv"
-     WScript.echo "   exec        Runs an executable by first preparing PATH so that the selected Python"
-     WScript.echo "   which       Display the full path to an executable"
-     WScript.echo "   whence      List all Python versions that contain the given executable"
-     WScript.echo ""
-     WScript.echo "See `pyenv help <command>' for information on a specific command."
-     WScript.echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
+    '  WScript.echo "kkotari: pyenv.vbs show help..!"
+     WScript.Echo "pyenv " & objfs.OpenTextFile(strPyenvParent & "\.version").ReadAll
+     WScript.Echo "Usage: pyenv <command> [<args>]"
+     WScript.Echo ""
+     WScript.Echo "Some useful pyenv commands are:"
+     WScript.Echo "   commands     List all available pyenv commands"
+     WScript.Echo "   duplicate    Creates a duplicate python environment"
+     WScript.Echo "   local        Set or show the local application-specific Python version"
+     WScript.Echo "   global       Set or show the global Python version"
+     WScript.Echo "   shell        Set or show the shell-specific Python version"
+     WScript.Echo "   install      Install a Python version using python-build"
+     WScript.Echo "   uninstall    Uninstall a specific Python version"
+     WScript.Echo "   update       Update the cached version DB"
+     WScript.echo "   rehash       Rehash pyenv shims (run this after installing executables)"
+     WScript.Echo "   vname        Show the current Python version"
+     WScript.Echo "   version      Show the current Python version and its origin"
+     WScript.Echo "   version-name Show the current Python version"
+     WScript.Echo "   versions     List all Python versions available to pyenv"
+     WScript.Echo "   exec         Runs an executable by first preparing PATH so that the selected Python"
+     WScript.Echo "   which        Display the full path to an executable"
+     WScript.Echo "   whence       List all Python versions that contain the given executable"
+     WScript.Echo ""
+     WScript.Echo "See `pyenv help <command>' for information on a specific command."
+     WScript.Echo "For full documentation, see: https://github.com/pyenv-win/pyenv-win#readme"
 End Sub
 
-Sub CommandHelp(arg)
-    If arg.Count > 1 Then
+Sub CommandScriptVersion(arg)
+    ' WScript.echo "kkotari: pyenv.vbs command script version..!"
+    If arg.Count = 1 Then
         Dim list
-        Set list=GetCommandList
-        If list.Exists(arg(1)) Then
-            ExecCommand(list(arg(1)) & " --help")
+        Set list = GetCommandList
+        If list.Exists(arg(0)) Then
+            PrintVersion "pyenv---version", 0
         Else
-             WScript.echo "unknown pyenv command '"&arg(1)&"'"
+             WScript.Echo "unknown pyenv command '"& arg(0) &"'"
         End If
     Else
         ShowHelp
     End If
 End Sub
 
+Sub CommandHelp(arg)
+    ShowHelp
+End Sub
 
 Sub CommandRehash(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-rehash.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
-    Dim strDirShims
-    strDirShims= strPyenvHome & "\shims"
-    If Not objfs.FolderExists( strDirShims ) Then objfs.CreateFolder(strDirShims)
-
-    Dim ofile
-    Dim file
-    For Each file In objfs.GetFolder(strDirShims).Files
-        objfs.DeleteFile file, True
-    Next
-
-    For Each file In objfs.GetFolder(GetBinDir(GetCurrentVersion()(0))).Files
-        If objfs.GetExtensionName(file) = "exe" or objfs.GetExtensionName(file) = "bat" or objfs.GetExtensionName(file) = "cmd" or objfs.GetExtensionName(file) = "py" Then
-          Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) & ".bat" )
-          ofile.WriteLine("@echo off")
-          ofile.WriteLine("pyenv exec %~n0 %*")
-          ofile.Close()
-          Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) )
-          ofile.WriteLine("#!/bin/sh")
-          ofile.WriteLine("pyenv exec $(basename ""$0"") $*")
-          ofile.Close()
-        End If
-    Next
-
-    If objfs.FolderExists(GetBinDir(GetCurrentVersion()(0)) & "\Scripts") Then
-        For Each file In objfs.GetFolder(GetBinDir(GetCurrentVersion()(0)) & "\Scripts").Files
-            If objfs.GetExtensionName(file) = "exe" or objfs.GetExtensionName(file) = "bat" or objfs.GetExtensionName(file) = "cmd" or objfs.GetExtensionName(file) = "py" Then
-            Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) & ".bat" )
-            ofile.WriteLine("@echo off")
-            ofile.WriteLine("pyenv exec Scripts/%~n0 %*")
-            ofile.Close()
-            Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) )
-            ofile.WriteLine("#!/bin/sh")
-            ofile.WriteLine("pyenv exec Scripts/$(basename ""$0"") $*")
-            ofile.Close()
-            End If
-        Next
-    End If
+    ' WScript.echo "kkotari: pyenv.vbs command rehash..!"
+    Rehash
 End Sub
 
 Sub CommandGlobal(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-global.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
+    ' WScript.echo "kkotari: pyenv.vbs command global..!"
+    Dim ver
     If arg.Count < 2 Then
-        Dim ver
-        ver=GetCurrentVersionGlobal()
+        ver = GetCurrentVersionGlobal()
         If IsNull(ver) Then
-            WScript.echo "no global version configured"
+            WScript.Echo "no global version configured"
         Else
-            WScript.echo ver(0)
+            WScript.Echo ver(0)
         End If
     Else
-        GetBinDir(arg(1))
-        Dim ofile
-        Set ofile = objfs.CreateTextFile( strPyenvHome & "\version" , True )
-        ofile.WriteLine(arg(1))
-        ofile.Close()
+        If arg(1) = "--unset" Then
+            ver = ""
+            objfs.DeleteFile strPyenvHome &"\version", True
+            Exit Sub
+        Else
+            ver = Check32Bit(arg(1))
+            SetGlobalVersion ver
+        End If
     End If
 End Sub
 
 Sub CommandLocal(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-local.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
+    ' WScript.echo "kkotari: pyenv.vbs command local..!"
     Dim ver
     If arg.Count < 2 Then
-        ver=GetCurrentVersionLocal(strCurrent)
-        If IsNull(ver) Then
-            WScript.echo "no local version configured for this directory"
+        Dim currentVersions
+        currentVersions = GetCurrentVersionsLocal(strCurrent)
+        If IsNull(currentVersions) Then
+            WScript.Echo "no local version configured for this directory"
         Else
-            WScript.echo ver(0)
+            For Each ver in currentVersions
+                WScript.Echo ver(0)
+            Next
         End If
     Else
-        ver=arg(1)
-        If ver = "--unset" Then
+        If arg(1) = "--unset" Then
             ver = ""
             objfs.DeleteFile strCurrent & strVerFile, True
             Exit Sub
         Else
-            GetBinDir(ver)
+            Dim versionCount
+            versionCount = arg.Count - 1
+            ReDim localVersions(versionCount - 1)
+            Dim i
+            For i = 0 To versionCount - 1
+                localVersions(i) = Check32Bit(arg(i + 1))
+                GetBinDir(localVersions(i))
+            Next
         End If
+
         Dim ofile
         If objfs.FileExists(strCurrent & strVerFile) Then
-          Set ofile = objfs.OpenTextFile ( strCurrent & strVerFile , 2 )
+            Set ofile = objfs.OpenTextFile(strCurrent & strVerFile, 2)
         Else
-          Set ofile = objfs.CreateTextFile( strCurrent & strVerFile , True )
+            Set ofile = objfs.CreateTextFile(strCurrent & strVerFile, True)
         End If
-        ofile.WriteLine(ver)
+        For Each ver in localVersions
+            ofile.WriteLine(ver)
+        Next
         ofile.Close()
     End If
 End Sub
 
-Sub CommandShell(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-shell.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
-    Dim ver
-    If arg.Count < 2 Then
-        ver=GetCurrentVersionShell
-        If IsNull(ver) Then
-            WScript.echo "no shell-specific version configured"
-        Else
-            WScript.echo ver(0)
-        End If
-    Else
-        ver=arg(1)
-        If ver = "--unset" Then
-            ver = ""
-        Else
-            GetBinDir(ver)
-        End If
-        ExecCommand("endlocal && set PYENV_VERSION=" & ver)
-    End If
-End Sub
-
 Sub CommandVersion(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-version.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
-    If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
+    ' WScript.echo "kkotari: pyenv.vbs command version..!"
+    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
 
     Dim curVer
-    curVer=GetCurrentVersion
-    WScript.echo curVer(0) & " (set by " &curVer(1)&")"
+    Dim versions
+    Set versions = GetCurrentVersions
+    For Each curVer In versions
+        WScript.Echo curVer &" (set by "& versions(curVer) &")"
+    Next
+End Sub
+
+Sub CommandVersionName(arg)
+    ' WScript.echo "kkotari: pyenv.vbs command version-name..!"
+    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
+
+    Dim ver, versions
+    Set versions = GetCurrentVersions
+    For Each ver in versions
+        WScript.Echo ver
+    Next
+End Sub
+
+Sub CommandVersionNameShort(arg)
+    ' WScript.echo "kkotari: pyenv.vbs command vname..!"
+    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
+
+    Dim ver, versions
+    Set versions = GetCurrentVersions
+    For Each ver in versions
+        WScript.Echo ver
+    Next
 End Sub
 
 Sub CommandVersions(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-versions.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
+    ' WScript.echo "kkotari: pyenv.vbs command versions..!"
     Dim isBare
-    isBare=False
+    isBare = False
     If arg.Count >= 2 Then
-        If arg(1) = "--bare" Then isBare=True
+        If arg(1) = "--bare" Then isBare = True
     End If
 
-    If Not objfs.FolderExists( strDirVers ) Then objfs.CreateFolder(strDirVers)
+    If Not objfs.FolderExists(strDirVers) Then objfs.CreateFolder(strDirVers)
 
-    Dim curVer
-    curVer=GetCurrentVersionNoError
-    If IsNull(curVer) Then
-        curVer=Array("","")
-    End If
+    Dim versions
+    Set versions = GetCurrentVersionsNoError
 
     Dim dir
     Dim ver
     For Each dir In objfs.GetFolder(strDirVers).subfolders
-        ver=objfs.GetFileName( dir )
+        ver = objfs.GetFileName(dir)
         If isBare Then
-            WScript.echo ver
-        ElseIf ver = curVer(0) Then
-            WScript.echo "* " & ver & " (set by " &curVer(1)&")"
+            WScript.Echo ver
+        ElseIf versions.Exists(ver) Then
+            WScript.Echo "* "& ver &" (set by "& versions(ver) &")"
         Else
-            WScript.echo "  " & ver
+            WScript.Echo "  "& ver
         End If
     Next
-End Sub
-
-Sub PlugIn(arg)
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-"&arg(0)&".bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
-    Dim fname
-    Dim idx
-    Dim str
-    fname = strDirLibs & "\pyenv-" & arg(0)
-    If objfs.FileExists( fname & ".bat" ) Then
-        str="""" & fname & ".bat"""
-    ElseIf objfs.FileExists( fname & ".vbs" ) Then
-        str="cscript //nologo """ & fname & ".vbs"""
-    Else
-       WScript.echo "pyenv: no such command `"&arg(0)&"'"
-       WScript.Quit
-    End If
-
-    For idx = 1 To arg.Count - 1
-      str=str & " """& arg(idx) &""""
-    Next
-
-    ExecCommand(str)
 End Sub
 
 Sub CommandCommands(arg)
+    ' WScript.echo "kkotari: pyenv.vbs command commands..!"
     Dim cname
 
-    If arg.Count >= 2 then
-        If arg(1) = "--help" then
-            help = getCommandOutput("cmd /c "&strDirLibs&"\pyenv-commands.bat --help")
-            WScript.echo help
-            Exit Sub
-        End If
-    End If
-
     For Each cname In GetCommandList()
-        WScript.echo cname
+        WScript.Echo cname
     Next
 End Sub
 
 Sub Dummy()
-     WScript.echo "command not implement"
+     WScript.Echo "command not implement"
 End Sub
 
 
 Sub main(arg)
+    ' WScript.echo "kkotari: pyenv.vbs main..!"
+    ' WScript.echo "kkotari: "&arg(0)
     If arg.Count = 0 Then
         ShowHelp
     Else
         Select Case arg(0)
-           Case "rehash"      CommandRehash(arg)
-           Case "global"      CommandGlobal(arg)
-           Case "local"       CommandLocal(arg)
-           Case "shell"       CommandShell(arg)
-           Case "version"     CommandVersion(arg)
-           Case "versions"    CommandVersions(arg)
-           Case "commands"    CommandCommands(arg)
-           Case "shims"       CommandShims(arg)
-           Case "which"       CommandWhich(arg)
-           Case "whence"      CommandWhence(arg)
-           Case "help"        CommandHelp(arg)
-           Case "--help"      CommandHelp(arg)
-           Case Else          PlugIn(arg)
+           Case "--version"    CommandScriptVersion(arg)
+           Case "rehash"       CommandRehash(arg)
+           Case "global"       CommandGlobal(arg)
+           Case "local"        CommandLocal(arg)
+           Case "version"      CommandVersion(arg)
+           Case "vname"        CommandVersionNameShort(arg)
+           Case "version-name" CommandVersionName(arg)
+           Case "versions"     CommandVersions(arg)
+           Case "commands"     CommandCommands(arg)
+           Case "shims"        CommandShims(arg)
+           Case "which"        CommandWhich(arg)
+           Case "whence"       CommandWhence(arg)
+           Case "help"         CommandHelp(arg)
+           Case "--help"       CommandHelp(arg)
         End Select
     End If
 End Sub
-
-
 
 main(WScript.Arguments)

--- a/tests/test_pyenv_feature_shell.py
+++ b/tests/test_pyenv_feature_shell.py
@@ -24,9 +24,9 @@ class TestPyenvFeatureShell(TestPyenvBase):
             tmp_bat = str(Path(ctx.local_path, "tmp.bat"))
             with open(tmp_bat, "w") as f:
                 # must chain commands because env var is lost when cmd ends
-                print(f'@call {pyenv_bat} shell 3.7.7 & call {pyenv_bat} shell', file=f)
+                print(f'@call {pyenv_bat} shell 3.7.7 && call {pyenv_bat} shell', file=f)
             args = ['cmd', '/d', '/c', 'call', tmp_bat]
-            result = subprocess.run(args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            result = subprocess.run(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output = str(result.stdout, "utf-8").strip()
             assert output == "3.7.7"
 

--- a/tests/test_pyenv_helpers.py
+++ b/tests/test_pyenv_helpers.py
@@ -49,6 +49,7 @@ def pyenv_setup(settings):
         os.makedirs(Path(pyenv_path, d))
     files = [r'bin\pyenv.bat',
              r'libexec\pyenv.vbs',
+             r'libexec\pyenv-shell.bat',
              r'libexec\libs\pyenv-install-lib.vbs',
              r'libexec\libs\pyenv-lib.vbs']
     for f in files:
@@ -106,7 +107,7 @@ def run_pyenv_test(settings, commands):
                         args = args + pyenv_args
                     else:
                         args.append(pyenv_args)
-                result = subprocess.run(args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                result = subprocess.run(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 stderr = str(result.stderr, "utf-8").strip()
                 if stderr != "":
                     print(stderr)


### PR DESCRIPTION
'exec' now handled directly in pyenv.bat
ExecCommand() in pyenv.vbs now uses WScript.Shell.exec()
  rather than creating 'exec.bat'