### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Get pyenv-win via one of the following methods:
    1. Add PYENV to your Environment Variables
          1. Using either PowerShell or Windows Terminal run
          ```
-         [System.Environment]::SetEnvironmentVariable('PYENV',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
+         [System.Environment]::SetEnvironmentVariable('PYENV_HOME',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
          ```
 
    2. Now add the following paths to your USER PATH variable in order to access the pyenv command. Run the following in PowerShell or Windows Terminal:


### PR DESCRIPTION
Fixes pyenv-win/pyenv-win#154

Updated the command to set the User's Environment variable.
The variable that is used by the pipenv is PYENV_HOME and not PYENV.