### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ I found a similar system for [rbenv-win][3] for ruby developers. This project wa
 Get pyenv-win via one of the following methods:
 
 - **With pip** (to support existing python users)
-   - Powershell or Git Bash: `pip install pyenv-win --target $HOME\.pyenv`
+   - Powershell or Git Bash: `pip install pyenv-win --target $HOME\\.pyenv`
    - cmd.exe: `pip install pyenv-win --target %USERPROFILE%\.pyenv`
 - **With zip file**
    1. Download link: [pyenv-win](https://github.com/pyenv-win/pyenv-win/archive/master.zip)


### PR DESCRIPTION
Installation command in PowerShell and Git Bash needs 2 backslashes. Otherwise, target directory is `$HOME.pyenv`.