### PR TITLE
added to cache following newest python versions 3.90[a5,a6,b1,b2,b3,b…

### DIFF
--- a/pyenv-win/.versions_cache.xml
+++ b/pyenv-win/.versions_cache.xml
@@ -2095,4 +2095,94 @@
 		<file>python-3.9.0a4-amd64-webinstall.exe</file>
 		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0a4-amd64-webinstall.exe</URL>
 	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0a5-win32</code>
+		<file>python-3.9.0a5-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0a5-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0a5</code>
+		<file>python-3.9.0a5-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0a5-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0a6-win32</code>
+		<file>python-3.9.0a6-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0a6-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0a6</code>
+		<file>python-3.9.0a6-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0a6-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0b1-win32</code>
+		<file>python-3.9.0b1-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b1-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0b1</code>
+		<file>python-3.9.0b1-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b1-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0b2-win32</code>
+		<file>python-3.9.0b2-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b2-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0b2</code>
+		<file>python-3.9.0b2-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b2-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0b3-win32</code>
+		<file>python-3.9.0b3-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b3-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0b3</code>
+		<file>python-3.9.0b3-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b3-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0b4-win32</code>
+		<file>python-3.9.0b4-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b4-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0b4</code>
+		<file>python-3.9.0b4-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b4-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0b5-win32</code>
+		<file>python-3.9.0b5-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b5-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0b5</code>
+		<file>python-3.9.0b5-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b5-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0b6-win32</code>
+		<file>python-3.9.0b6-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b6-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0b6</code>
+		<file>python-3.9.0b6-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0b6-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0-win32</code>
+		<file>python-3.9.0-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0</code>
+		<file>python-3.9.0-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64-webinstall.exe</URL>
+	</version>
 </versions>


### PR DESCRIPTION
Due to the need of newest python releases for example GA 3.9.0, updated .versions_cache.xml