### PR TITLE
Add support for python 3.9.0 and 3.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Both releases can install 64bit and 32bit python versions; the difference is in 
 3.8.1
 3.8.2-win32
 3.8.2
+3.9.0-win32
+3.9.0
 ....
 ```
 
@@ -245,7 +247,7 @@ Now follow the steps to "[finish the installation](#finish-the-installation)".
 - Create an upstream remote and sync your local copy before you branch.
 - Branch for each separate piece of work. It's good practice to write test cases.
 - Do the work, write good commit messages, and read the CONTRIBUTING file if there is one.
-- Test the changes by running `tests\test_install.bat` and `tests\test_uninstall.bat`
+- Test the changes by running `tests\bat_files\test_install.bat` and `tests\bat_files\test_uninstall.bat`
 - Push to your origin repository.
 - Create a new Pull Request in GitHub.
 

--- a/pyenv-win/.versions_cache.xml
+++ b/pyenv-win/.versions_cache.xml
@@ -2105,4 +2105,24 @@
 		<file>python-3.9.0a4-amd64-webinstall.exe</file>
 		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0a4-amd64-webinstall.exe</URL>
 	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.0-win32</code>
+		<file>python-3.9.0-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.0</code>
+		<file>python-3.9.0-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.9.1-win32</code>
+		<file>python-3.9.1-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.1/python-3.9.1-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.9.1</code>
+		<file>python-3.9.1-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.9.1/python-3.9.1-amd64-webinstall.exe</URL>
+	</version>
 </versions>

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,5 +4,5 @@ coveralls==1.5.1
 # This is needed to avoid ImportError: cannot import name 'Reporter' from 'coverage.report'
 # when Travis CI install requirements_dev.txt
 # See https://youtrack.jetbrains.com/issue/PY-40980
-coverage<5.0.0
+coverage==4.5.4
 pathlib==1.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pytest-cov==2.8.1
 pytest==5.3.0
-coveralls==1.5.1
+coveralls==1.7.0
 # This is needed to avoid ImportError: cannot import name 'Reporter' from 'coverage.report'
 # when Travis CI install requirements_dev.txt
 # See https://youtrack.jetbrains.com/issue/PY-40980

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,8 @@
 pytest-cov==2.8.1
 pytest==5.3.0
 coveralls==1.5.1
+# This is needed to avoid ImportError: cannot import name 'Reporter' from 'coverage.report'
+# when Travis CI install requirements_dev.txt
+# See https://youtrack.jetbrains.com/issue/PY-40980
+coverage<5.0.0
 pathlib==1.0.1

--- a/tests/bat_files/test_install.bat
+++ b/tests/bat_files/test_install.bat
@@ -11,6 +11,8 @@ call pyenv install 2.7.15
 call pyenv rehash 2.7.15
 call pyenv install 3.7.2
 call pyenv rehash 3.7.2
+call pyenv install 3.9.0
+call pyenv rehash 3.9.0
 
 mkdir test
 cd test

--- a/tests/bat_files/test_uninstall.bat
+++ b/tests/bat_files/test_uninstall.bat
@@ -8,4 +8,5 @@ call pyenv versions
 call pyenv uninstall 3.5.2
 call pyenv uninstall --msi 2.7.15
 call pyenv uninstall 3.7.2
+call pyenv uninstall 3.9.0
 

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -5,8 +5,29 @@ class TestPyenvFeatureInstall(TestPyenvBase):
     def test_check_pyenv_install_list(self, setup):
         result = subprocess.run(['pyenv', 'install', '-l'], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result = str(result.stdout, "utf-8")
-        print(result)
-        assert True
+        assert "Mirror: https://www.python.org/ftp/python" in result
+        assert "2.7.17-win32" in result
+        assert "2.7.17" in result
+        assert "3.1.4-win32" in result
+        assert "3.1.4" in result
+        assert "3.2.5-win32" in result
+        assert "3.2.5" in result
+        assert "3.3.5-win32" in result
+        assert "3.3.5" in result
+        assert "3.4.4-win32" in result
+        assert "3.4.4" in result
+        assert "3.5.4-win32" in result
+        assert "3.5.4" in result
+        assert "3.6.8-win32" in result
+        assert "3.6.8" in result
+        assert "3.7.7-win32" in result
+        assert "3.7.7" in result
+        assert "3.8.2-win32" in result
+        assert "3.8.2" in result
+        assert "3.9.0-win32" in result
+        assert "3.9.0" in result
+        assert "3.9.1-win32" in result
+        assert "3.9.1" in result
     
     def test_check_pyenv_installation(self, setup):
         # TODO: tracking the logs of installation and checking the folder


### PR DESCRIPTION
Extend the list of supported python versions from the official Python FTP server to include 3.9.0 and 3.9.1

* Fix coveralls stage in travis CI by adapting requirements_dev.txt
* Fix path to testing scripts in README.md
* Extend version cache to list 3.9.0 and 3.9.1 versions
* Add 3.9.1 to bat testing
* Add implementation for test_check_pyenv_install_list pytest test case