### PR TITLE
Add support for PYTHON_BUILD_MIRROR_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Now follow the steps to "[finish the installation](#finish-the-installation)".
 - Create an upstream remote and sync your local copy before you branch.
 - Branch for each separate piece of work. It's good practice to write test cases.
 - Do the work, write good commit messages, and read the CONTRIBUTING file if there is one.
-- Test the changes by running `tests\bat_files\test_install.bat` and `tests\bat_files\test_uninstall.bat`
+- Test the changes by running `tests\bat_files\test_install.bat` and `tests\bat_files\test_uninstall.bat` and `PYTHONPATH=. python -m pytest -v -s tests`
 - Push to your origin repository.
 - Create a new Pull Request in GitHub.
 

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -335,9 +335,7 @@ Sub main(arg)
                 strDirCache &"\"& verDef(LV_FileName), _
                 optQuiet _
             )
-            If Not mirror = "https://www.python.org/ftp/python" Then
-                installParams(LV_URL) = mirror &""& verDef(LV_Code) &"/"& verDef(LV_FileName)
-            End If
+            installParams(LV_URL) = mirror &""& verDef(LV_Code) &"/"& verDef(LV_FileName)
             If optForce Then clear(installParams)
             extract(installParams)
             installed(version) = Empty

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -335,7 +335,7 @@ Sub main(arg)
                 strDirCache &"\"& verDef(LV_FileName), _
                 optQuiet _
             )
-            installParams(LV_URL) = mirror &""& verDef(LV_Code) &"/"& verDef(LV_FileName)
+            installParams(LV_URL) = mirror &"/"& verDef(LV_Code) &"/"& verDef(LV_FileName)
             If optForce Then clear(installParams)
             extract(installParams)
             installed(version) = Empty

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -335,6 +335,9 @@ Sub main(arg)
                 strDirCache &"\"& verDef(LV_FileName), _
                 optQuiet _
             )
+            If Not mirror = "https://www.python.org/ftp/python" Then
+                installParams(LV_URL) = mirror &""& verDef(LV_Code) &"/"& verDef(LV_FileName)
+            End If
             If optForce Then clear(installParams)
             extract(installParams)
             installed(version) = Empty

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -28,7 +28,14 @@ class TestPyenvFeatureInstall(TestPyenvBase):
         assert "3.9.0" in result
         assert "3.9.1-win32" in result
         assert "3.9.1" in result
-    
+
+    def test_check_pyenv_install_mirror(self, setup):
+        mirror_url = "https://my.artifactory.domain.com/artifactory/my-repo/python/"
+        result = subprocess.run(['pyenv', 'install', '-l'],shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                env={"PYTHON_BUILD_MIRROR_URL": mirror_url})
+        result = str(result.stdout, "utf-8")
+        assert f"Mirror: {mirror_url}" in result
+
     def test_check_pyenv_installation(self, setup):
         # TODO: tracking the logs of installation and checking the folder
         pass

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -31,15 +31,13 @@ class TestPyenvFeatureInstall(TestPyenvBase):
         assert "3.9.1" in result
 
     def test_check_pyenv_install_mirror(self, setup):
-        mirror_url = "https://my.artifactory.domain.com/artifactory/my-repo/python/"
+        mirror_url = "http://mirrors.sohu.com/python/"
         test_env = os.environ.copy()
         test_env["PYTHON_BUILD_MIRROR_URL"] = mirror_url
         result = subprocess.run(['pyenv', 'install', '3.8.2'],
                                 shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                 env=test_env)
         result = str(result.stdout, "utf-8")
-        # result will be failed since mirror is not available, but we check only script output
-        # to see if the mirror was chosen as a source
         assert f"Mirror: {mirror_url}" in result
 
     def test_check_pyenv_installation(self, setup):

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -31,9 +31,12 @@ class TestPyenvFeatureInstall(TestPyenvBase):
 
     def test_check_pyenv_install_mirror(self, setup):
         mirror_url = "https://my.artifactory.domain.com/artifactory/my-repo/python/"
-        result = subprocess.run(['pyenv', 'install', '-l'],shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        result = subprocess.run(['pyenv', 'install', '3.8.2'],
+                                shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                 env={"PYTHON_BUILD_MIRROR_URL": mirror_url})
         result = str(result.stdout, "utf-8")
+        # result will be failed since mirror is not available, but we check only script output
+        # to see if the mirror was chosen as a source
         assert f"Mirror: {mirror_url}" in result
 
     def test_check_pyenv_installation(self, setup):

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -33,7 +33,7 @@ class TestPyenvFeatureInstall(TestPyenvBase):
     def test_check_pyenv_install_mirror(self, setup):
         mirror_url = "https://my.artifactory.domain.com/artifactory/my-repo/python/"
         test_env = os.environ.copy()
-	test_env["PYTHON_BUILD_MIRROR_URL"] = mirror_url
+        test_env["PYTHON_BUILD_MIRROR_URL"] = mirror_url
         result = subprocess.run(['pyenv', 'install', '3.8.2'],
                                 shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                 env=test_env)

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -34,7 +34,7 @@ class TestPyenvFeatureInstall(TestPyenvBase):
         result = subprocess.run(['pyenv', 'install', '3.8.2'],
                                 shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                 env={"PYTHON_BUILD_MIRROR_URL": mirror_url})
-        result = str(result.stdout, "utf-8")
+        result = str(result.stderr, "utf-8")
         # result will be failed since mirror is not available, but we check only script output
         # to see if the mirror was chosen as a source
         assert f"Mirror: {mirror_url}" in result

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from test_pyenv import TestPyenvBase
 
@@ -31,10 +32,12 @@ class TestPyenvFeatureInstall(TestPyenvBase):
 
     def test_check_pyenv_install_mirror(self, setup):
         mirror_url = "https://my.artifactory.domain.com/artifactory/my-repo/python/"
+        test_env = os.environ.copy()
+	test_env["PYTHON_BUILD_MIRROR_URL"] = mirror_url
         result = subprocess.run(['pyenv', 'install', '3.8.2'],
                                 shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                env={"PYTHON_BUILD_MIRROR_URL": mirror_url})
-        result = str(result.stderr, "utf-8")
+                                env=test_env)
+        result = str(result.stdout, "utf-8")
         # result will be failed since mirror is not available, but we check only script output
         # to see if the mirror was chosen as a source
         assert f"Mirror: {mirror_url}" in result


### PR DESCRIPTION
Behave like pyenv: when PYTHON_BUILD_MIRROR_URL is set, pyenv-win will honor it and try to install from that mirror instead of https://www.python.org/ftp/python

This feature is useful when the host does not have access to internet.