### PR TITLE
git bash shell corrections

### DIFF
--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -276,7 +276,7 @@ Sub WriteLinuxScript(baseName, strDirBin)
     If Not objfs.FileExists(filespec) Then
         With objfs.CreateTextFile(filespec)
             .WriteLine("#!/bin/sh")
-            .WriteLine("pyenv exec "&strDirBin&"$(basename $0) ""$@""")
+            .WriteLine("pyenv exec "&strDirBin&"$(basename ""$0"") ""$@""")
             .Close
         End With
     End If


### PR DESCRIPTION
If username contains space in between the bash shell will throw an incorrect filename - Resolved