### PR TITLE
Correctly handle spaces in the path of pyenv.bat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Now follow the steps to "[finish the installation](#finish-the-installation)".
 ## Change Log
 
 ### New in 2.64.11
+- Fix [#259](https://github.com/pyenv-win/pyenv-win/issues/259): Correctly handle spaces in `pyenv` path
 - Fix [#305](https://github.com/pyenv-win/pyenv-win/issues/305): Fix `exec` preferring the last version listed in `.python-version` instead of the first.
 
 ### New in 2.64.10

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -2,20 +2,20 @@
 setlocal
 chcp 1250 >nul
 
-set "pyenv=cscript //nologo "%~dp0..\libexec\pyenv.vbs""
+set "__pyenv_pyenv=cscript //nologo "%~dp0..\libexec\pyenv.vbs""
 
 :: if 'pyenv' called alone, then run pyenv.vbs
 if [%1]==[] (
-  %pyenv%
+  %__pyenv_pyenv%
   exit /b
 )
 
 if /i [%1%2]==[version] call :check_path
 
-:: use pyenv.vbs to aid resolving absolute path of "active" version into 'bindir'
-set "bindir="
-set "extrapaths="
-for /f %%i in ('%pyenv% vname') do call :extrapath "%~dp0..\versions\%%i"
+:: use pyenv.vbs to aid resolving absolute path of "active" version into '__pyenv_bindir'
+set "__pyenv_bindir="
+set "__pyenv_extrapaths="
+for /f %%i in ('%__pyenv_pyenv% vname') do call :extrapath "%~dp0..\versions\%%i"
 
 :: all help implemented as plugin
 if /i [%2]==[--help] goto :plugin
@@ -30,13 +30,13 @@ if /i [%1]==[help] (
 )
 
 :: let pyenv.vbs handle these
-set commands=rehash global local version vname version-name versions commands shims which whence help --help
-for %%a in (%commands%) do (
+set "__pyenv_commands=rehash global local version vname version-name versions commands shims which whence help --help"
+for %%a in (%__pyenv_commands%) do (
   if /i [%1]==[%%a] (
     rem endlocal not really needed here since above commands do not set any variable
     rem endlocal closed automatically with exit
     rem no need to update PATH either
-    %pyenv% %*
+    %__pyenv_pyenv% %*
     exit /b
   )
 )
@@ -46,57 +46,57 @@ if /i not [%1]==[exec] goto :plugin
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :exec
 
-if not exist "%bindir%" (
+if not exist "%__pyenv_bindir%" (
   echo No global python version has been set yet. Please set the global version by typing:
   echo pyenv global 3.7.2
   exit /b
 )
 
-set cmdline=%*
-set cmdline=%cmdline:~5%
+set "__pyenv_cmdline=%*"
+set "__pyenv_cmdline=%__pyenv_cmdline:~5%"
 :: update PATH to active version and run command
 :: endlocal needed only if cmdline sets a variable: SET FOO=BAR
-set "path=%extrapaths%%path%"
-%cmdline%
+set "path=%__pyenv_extrapaths%%path%"
+%__pyenv_cmdline%
 endlocal
 exit /b
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :plugin
-set "exe=%~dp0..\libexec\pyenv-%1"
+set "__pyenv_exe=%~dp0..\libexec\pyenv-%1"
 rem TODO needed?
-call :normalizepath %exe% exe
+call :normalizepath %__pyenv_exe% __pyenv_exe
 
-if exist "%exe%.bat" (
-  set "exe=call "%exe%.bat""
+if exist "%__pyenv_exe%.bat" (
+  set "__pyenv_exe=call "%__pyenv_exe%.bat""
 
-) else if exist "%exe.cmd%" (
-  set "exe=call "%exe%.cmd""
+) else if exist "%__pyenv_exe%.cmd" (
+  set "__pyenv_exe=call "%__pyenv_exe%.cmd""
 
-) else if exist "%exe%.vbs" (
-  set "exe=cscript //nologo "%exe%.vbs""
+) else if exist "%__pyenv_exe%.vbs" (
+  set "__pyenv_exe=cscript //nologo "%__pyenv_exe%.vbs""
 
 ) else (
   echo pyenv: no such command '%1'
   exit /b 1
 )
 
-:: replace first arg with %exe%
-set cmdline=%*
-set cmdline=%cmdline:^=^^%
-set cmdline=%cmdline:!=^!%
-set arg1=%1
-set len=1
+:: replace first arg with %__pyenv_exe%
+set "__pyenv_cmdline=%*"
+set "__pyenv_cmdline=%__pyenv_cmdline:^=^^%"
+set "__pyenv_cmdline=%__pyenv_cmdline:!=^!%"
+set "__pyenv_arg1=%1"
+set "__pyenv_len=1"
 :loop_len
-set /a len=%len%+1
-set "arg1=%arg1:~1%"
-if not [%arg1%]==[] goto :loop_len
+set /a __pyenv_len=%__pyenv_len%+1
+set "__pyenv_arg1=%__pyenv_arg1:~1%"
+if not [%__pyenv_arg1%]==[] goto :loop_len
 
 setlocal enabledelayedexpansion
-set "cmdline=!exe! !cmdline:~%len%!"
+set "__pyenv_cmdline=!__pyenv_exe! !__pyenv_cmdline:~%__pyenv_len%!"
 :: run command (no need to update PATH for plugins)
 :: endlocal needed to ensure exit will not automatically close setlocal
 :: otherwise PYTHON_VERSION will be lost
-endlocal && endlocal && %cmdline%
+endlocal && endlocal && %__pyenv_cmdline%
 exit /b
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: convert path which may have relative nodes (.. or .)
@@ -107,32 +107,32 @@ goto :eof
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: compute list of paths to add for all activated python versions
 :extrapath
-call :normalizepath %1 bindir
-set "extrapaths=%extrapaths%%bindir%;%bindir%\Scripts;"
+call :normalizepath %1 __pyenv_bindir
+set "__pyenv_extrapaths=%__pyenv_extrapaths%%__pyenv_bindir%;%__pyenv_bindir%\Scripts;"
 goto :eof
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: check pyenv python shim is first in PATH
 :check_path
-set "python_shim=%~dp0..\shims\python.bat"
-if not exist "%python_shim%" goto :eof
-call :normalizepath %python_shim% python_shim
-set "python_where="
-for /f "delims=" %%f in ('where python') do call :set_python_where %%f
+set "__pyenv_python_shim=%~dp0..\shims\python.bat"
+if not exist "%__pyenv_python_shim%" goto :eof
+call :normalizepath "%__pyenv_python_shim%" __pyenv_python_shim
+set "__pyenv_python_where="
+for /f "delims=" %%f in ('where python') do call :set_python_where "%%f"
 :: On recent Windows versions, where finds python shim with shebang first
-if /i [%python_shim%]==[%python_where%.bat] goto :eof
-if /i [%python_shim%]==[%python_where%] goto :eof
-call :bad_path "%python_where%"
+if /i "%__pyenv_python_shim%"=="%__pyenv_python_where:~1,-1%.bat" goto :eof
+if /i "%__pyenv_python_shim%"=="%__pyenv_python_where:~1,-1%" goto :eof
+call :bad_path %__pyenv_python_where%
 exit /b 1
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: set python_where variable if empty
+:: set __pyenv_python_where variable if empty
 :set_python_where
-if [%python_where%]==[] set "python_where=%~1"
+if [%__pyenv_python_where%]==[] set "__pyenv_python_where="%~1""
 goto :eof
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: tell bad PATH and exit
 :bad_path
-set bad_python=%~1
-set bad_dir=%~dp1
-echo [91mFATAL: Found [95m%bad_python%[91m version before pyenv in PATH.[0m
-echo [91mPlease remove [95m%bad_dir%[91m from PATH for pyenv to work properly.[0m
+set "__pyenv_bad_python=%~1"
+set "__pyenv_bad_dir=%~dp1"
+echo [91mFATAL: Found [95m%__pyenv_bad_python%[91m version before pyenv in PATH.[0m
+echo [91mPlease remove [95m%__pyenv_bad_dir%[91m from PATH for pyenv to work properly.[0m
 goto :eof

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -46,7 +46,7 @@ End Function
 Sub PrintVersion(cmd, exitCode)
     ' WScript.echo "kkotari: pyenv.vbs print version..!"
     Dim help
-    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat")
+    help = getCommandOutput("cmd /c """& strDirLibs &"\"& cmd &".bat""")
     WScript.Echo help
     WScript.Quit exitCode
 End Sub
@@ -54,7 +54,7 @@ End Sub
 Sub PrintHelp(cmd, exitCode)
     ' WScript.echo "kkotari: pyenv.vbs print help..!"
     Dim help
-    help = getCommandOutput("cmd /c "& strDirLibs &"\"& cmd &".bat --help")
+    help = getCommandOutput("cmd /c """& strDirLibs &"\"& cmd &".bat"" --help")
     WScript.Echo help
     WScript.Quit exitCode
 End Sub
@@ -154,7 +154,7 @@ Sub CommandWhich(arg)
 
     WScript.Echo "pyenv: "& arg(1) &": command not found"
 
-    version = getCommandOutput("cscript //Nologo "& WScript.ScriptFullName &" whence "& program)
+    version = getCommandOutput("cscript //Nologo """& WScript.ScriptFullName &""" whence "& program)
     If Trim(version) <> "" Then
         WScript.Echo
         WScript.Echo "The '"& arg(1) &"' command exists in these Python versions:"

--- a/tests/test_pyenv_feature_exec.py
+++ b/tests/test_pyenv_feature_exec.py
@@ -117,7 +117,7 @@ class TestPyenvFeatureExec(TestPyenvBase):
         with open(tmp_bat, "w") as f:
             # must chain commands because env var is lost when cmd ends
             print(f'@echo %PATH%', file=f)
-            print(f'@call {python} -V>nul', file=f)
+            print(f'@call "{python}" -V>nul', file=f)
             print(f'@echo %PATH%', file=f)
         args = ["call", tmp_bat]
         stdout, stderr = self.__class__.ctx.exec(args)

--- a/tests/test_pyenv_feature_shell.py
+++ b/tests/test_pyenv_feature_shell.py
@@ -41,7 +41,7 @@ class TestPyenvFeatureShell(TestPyenvBase):
             tmp_bat = str(Path(ctx.local_path, "tmp.bat"))
             with open(tmp_bat, "w") as f:
                 # must chain commands because env var is lost when cmd ends
-                print(f'@call {pyenv_bat} shell 3.7.7 && call {pyenv_bat} shell', file=f)
+                print(f'@call "{pyenv_bat}" shell 3.7.7 && call "{pyenv_bat}" shell', file=f)
             args = ['cmd', '/d', '/c', 'call', tmp_bat]
             result = subprocess.run(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output = str(result.stdout, "utf-8").strip()

--- a/tests/test_pyenv_helpers.py
+++ b/tests/test_pyenv_helpers.py
@@ -103,8 +103,8 @@ class PyenvContext:
 class TempPyEnv:
     def __init__(self, settings):
         self.tmp_path = tempfile.TemporaryDirectory()
-        settings['pyenv_path'] = pyenv_path = Path(self.tmp_path.name, 'pyenv')
-        settings['local_path'] = local_path = Path(self.tmp_path.name, 'local')
+        settings['pyenv_path'] = pyenv_path = Path(self.tmp_path.name, 'pyenv dir with spaces')
+        settings['local_path'] = local_path = Path(self.tmp_path.name, 'local dir with spaces')
         os.mkdir(pyenv_path)
         os.mkdir(local_path)
         pyenv_setup(settings)


### PR DESCRIPTION
Fixes #259

Depends on #306 