### PR TITLE
[Docs] Replace PYENV_HOME with PYENV_ROOT for pipenv

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,5 +1,6 @@
 export HOME="/d/a/pyenv-win/pyenv-win"
 export PYENV="$HOME/pyenv-win"
+export PYENV_HOME="$HOME/pyenv-win"
 export PYENV_ROOT="$HOME/pyenv-win"
 export PATH="$PYENV/bin:$PYENV/shims:$PATH"
 

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,6 +1,6 @@
 export HOME="/d/a/pyenv-win/pyenv-win"
 export PYENV="$HOME/pyenv-win"
-export PYENV_HOME="$HOME/pyenv-win"
+export PYENV_ROOT="$HOME/pyenv-win"
 export PATH="$PYENV/bin:$PYENV/shims:$PATH"
 
 pyenv --version

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Get pyenv-win via one of the following methods:
 
    If you installed using Chocolatey, you can skip to step 3.
 
-   1. Add PYENV and PYENV_HOME to your Environment Variables
+   1. Add PYENV and PYENV_ROOT to your Environment Variables
          1. Using either PowerShell or Windows 8/above Terminal run
          ```
          [System.Environment]::SetEnvironmentVariable('PYENV',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
-         [System.Environment]::SetEnvironmentVariable('PYENV_HOME',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
+         [System.Environment]::SetEnvironmentVariable('PYENV_ROOT',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
          ```
-         Note: PYENV_HOME is to support pipenv
+         Note: PYENV_ROOT is to support pipenv
 
    2. Now add the following paths to your USER PATH variable in order to access the pyenv command. Run the following in PowerShell or Windows 8/above Terminal:
       

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Get pyenv-win via one of the following methods:
 
    If you installed using Chocolatey, you can skip to step 3.
 
-   1. Add PYENV and PYENV_ROOT to your Environment Variables
+   1. Add PYENV, PYENV_HOME and PYENV_ROOT to your Environment Variables
          1. Using either PowerShell or Windows 8/above Terminal run
          ```
          [System.Environment]::SetEnvironmentVariable('PYENV',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
          [System.Environment]::SetEnvironmentVariable('PYENV_ROOT',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
+         [System.Environment]::SetEnvironmentVariable('PYENV_HOME',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
          ```
-         Note: `PYENV_ROOT` is to support pipenv. In case another application is unable to find/use pyenv, try setting `PYENV_HOME` as well for compatibility, using the above command and replacing `ROOT` with `HOME`.
 
    2. Now add the following paths to your USER PATH variable in order to access the pyenv command. Run the following in PowerShell or Windows 8/above Terminal:
       

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Get pyenv-win via one of the following methods:
          [System.Environment]::SetEnvironmentVariable('PYENV',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
          [System.Environment]::SetEnvironmentVariable('PYENV_ROOT',$env:USERPROFILE + "\.pyenv\pyenv-win\","User")
          ```
-         Note: PYENV_ROOT is to support pipenv
+         Note: `PYENV_ROOT` is to support pipenv. In case another application is unable to find/use pyenv, try setting `PYENV_HOME` as well for compatibility, using the above command and replacing `ROOT` with `HOME`.
 
    2. Now add the following paths to your USER PATH variable in order to access the pyenv command. Run the following in PowerShell or Windows 8/above Terminal:
       


### PR DESCRIPTION
I've been doing some work on pipenv and according to pipenv's codebase it only checks `PYENV_ROOT`, not `PYENV_HOME` like it says in the README. As a result I don't think we need to set PYENV_HOME but please let me know if its needed for some other tool or application other than pipenv.

In order to get pipenv to properly detect pyenv-win I manually set PYENV_ROOT. 

Thanks for your consideration!