### PR TITLE
Increase compatibility with cygwin

### DIFF
--- a/pyenv-win/bin/pyenv
+++ b/pyenv-win/bin/pyenv
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cmd //c call "$(dirname "$0")/pyenv.bat" "$@"
+MSYS2_ARG_CONV_EXCL="/C" exec cmd /C call "$(cygpath -wa "$(dirname "$0")")/pyenv.bat" "$@"; # sould work on both cygwin and git-bash/mingw


### PR DESCRIPTION
mingw and git-bash uses a heuristic for converting "Unix-like" paths to Windows paths.
This heuristic can fail with certain paths.

Using the environment variable `MSYS2_ARG_CONV_EXCL="/C"` disables the heuristic for `/C`, and `cygpath -wa` converts the given path in windows format.

cygwin has no euristic, thus `pyenv` always fails.
`MSYS2_ARG_CONV_EXCL="/C"` in cygwin is an environment variable that is simply ignored, and `cygpath -wa` converts the cygwin specific path to a Windows path.