### PR TITLE
Fix bug: Wrong shim is created for python 3.10 #339

### DIFF
--- a/pyenv-win/.versions_cache.xml
+++ b/pyenv-win/.versions_cache.xml
@@ -2555,6 +2555,101 @@
 		<file>python-3.10.0b3-amd64-webinstall.exe</file>
 		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0b3-amd64-webinstall.exe</URL>
 	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.10.0b4</code>
+		<file>python-3.10.0b4-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0b4-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.10.0rc1-win32</code>
+		<file>python-3.10.0rc1-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0rc1-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.10.0rc1</code>
+		<file>python-3.10.0rc1-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0rc1-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.10.0rc2-win32</code>
+		<file>python-3.10.0rc2-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0rc2-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.10.0rc2</code>
+		<file>python-3.10.0rc2-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0rc2-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.10.0-win32</code>
+		<file>python-3.10.0-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.10.0</code>
+		<file>python-3.10.0-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.10.1-win32</code>
+		<file>python-3.10.1-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.1/python-3.10.1-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.10.1</code>
+		<file>python-3.10.1-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.1/python-3.10.1-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.10.2-win32</code>
+		<file>python-3.10.2-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.2/python-3.10.2-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.10.2</code>
+		<file>python-3.10.2-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.11.0a1-win32</code>
+		<file>python-3.11.0a1-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a1-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.11.0a1</code>
+		<file>python-3.11.0a1-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a1-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.11.0a2-win32</code>
+		<file>python-3.11.0a2-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a2-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.11.0a2</code>
+		<file>python-3.11.0a2-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a2-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.11.0a3-win32</code>
+		<file>python-3.11.0a3-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a3-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.11.0a3</code>
+		<file>python-3.11.0a3-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a3-amd64-webinstall.exe</URL>
+	</version>
+	<version x64="false" webInstall="true" msi="false">
+		<code>3.11.0a4-win32</code>
+		<file>python-3.11.0a4-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a4-webinstall.exe</URL>
+	</version>
+	<version x64="true" webInstall="true" msi="false">
+		<code>3.11.0a4</code>
+		<file>python-3.11.0a4-amd64-webinstall.exe</file>
+		<URL>https://www.python.org/ftp/python/3.11.0/python-3.11.0a4-amd64-webinstall.exe</URL>
+	</version>
 	<version x64="false" webInstall="false" msi="false">
 		<code>pypy3.6-v7.3.3-win32</code>
 		<file>pypy3.6-v7.3.3-win32.zip</file>

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -135,8 +135,8 @@ Function deepExtract(params)
     version = params(LV_Code)
     pythonExe = installPath &"\python.exe"
     pythonwExe = installPath &"\pythonw.exe"
-    major = Left(version, 1)
-    minor = Mid(version, 3, 1)
+    major = Split(version,".")(0)
+    minor = Split(version, ".")(1)
     majorMinor = major & minor
     majorDotMinor = major &"."& minor
     objfs.CopyFile pythonExe, installPath &"\python"& major &".exe"

--- a/tests/bat_files/test_install.bat
+++ b/tests/bat_files/test_install.bat
@@ -13,6 +13,8 @@ call pyenv install 3.7.2
 call pyenv rehash 3.7.2
 call pyenv install 3.9.0
 call pyenv rehash 3.9.0
+call pyenv install 3.10.0
+call pyenv rehash 3.10.0
 
 mkdir test
 cd test

--- a/tests/bat_files/test_uninstall.bat
+++ b/tests/bat_files/test_uninstall.bat
@@ -9,4 +9,5 @@ call pyenv uninstall 3.5.2
 call pyenv uninstall --msi 2.7.15
 call pyenv uninstall 3.7.2
 call pyenv uninstall 3.9.0
+call pyenv uninstall 3.10.0
 

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -29,7 +29,8 @@ class TestPyenvFeatureInstall(TestPyenvBase):
         assert "3.9.0" in result
         assert "3.9.1-win32" in result
         assert "3.9.1" in result
-    
+        assert "3.10.2-win32" in result
+        assert "3.10.2" in result
     def test_check_pyenv_installation(self, setup):
         # TODO: tracking the logs of installation and checking the folder
         pass

--- a/tests/test_pyenv_feature_rehash.py
+++ b/tests/test_pyenv_feature_rehash.py
@@ -29,8 +29,9 @@ class TestPyenvFeatureRehash(TestPyenvBase):
             assert ctx.pyenv('rehash') == ("", "")
             assert_shims(ctx.pyenv_path, '3.8.6')
             assert_shims(ctx.pyenv_path, '3.8.7')
+            assert_shims(ctx.pyenv_path, '3.10.2')
         settings = {
-            'versions': ['3.8.6', '3.8.7'],
+            'versions': ['3.8.6', '3.8.7','3.10.2'],
             'global_ver': '3.8.6',
         }
         run_pyenv_test(settings, commands)
@@ -40,8 +41,9 @@ class TestPyenvFeatureRehash(TestPyenvBase):
             assert ctx.pyenv('rehash') == ("", "")
             assert_shims(ctx.pyenv_path, '3.8.6')
             assert_shims(ctx.pyenv_path, '3.9.1')
+            assert_shims(ctx.pyenv_path, '3.10.2')
         settings = {
-            'versions': ['3.8.6', '3.9.1'],
+            'versions': ['3.8.6', '3.9.1','3.10.2'],
             'global_ver': '3.8.6',
             'local_ver': '3.9.1'
         }


### PR DESCRIPTION
Python 3.10 and above will have 2 digit minor version numbers.
The `deepExtract` method assumed only one. This uses Split instead of Mid and Left.

Update tests and version cache to include Python 3.10 to be able to test the shims.