### PR TITLE
Adds -s/--skip-existing option

### DIFF
--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -25,16 +25,17 @@ Sub ShowHelp()
     WScript.Echo "       pyenv install [-f] -c|--clear"
     WScript.Echo "       pyenv install -l|--list"
     WScript.Echo ""
-    WScript.Echo "  -l/--list      List all available versions"
-    WScript.Echo "  -a/--all       Installs all known version from the local version DB cache"
-    WScript.Echo "  -c/--clear     Removes downloaded installers from the cache to free space"
-    WScript.Echo "  -f/--force     Install even if the version appears to be installed already"
-    WScript.Echo "  -r/--register  Register version for py launcher"
-    WScript.Echo "  -q/--quiet     Install using /quiet. This does not show the UI nor does it prompt for inputs"
-    WScript.Echo "  --32only       Installs only 32bit Python using -a/--all switch, no effect on 32-bit windows."
-    WScript.Echo "  --64only       Installs only 64bit Python using -a/--all switch, no effect on 32-bit windows."
-    WScript.Echo "  --dev          Installs precompiled standard libraries, debug symbols, and debug binaries (only applies to web installer)."
-    WScript.Echo "  --help         Help, list of options allowed on pyenv install"
+    WScript.Echo "  -l/--list              List all available versions"
+    WScript.Echo "  -a/--all               Installs all known version from the local version DB cache"
+    WScript.Echo "  -c/--clear             Removes downloaded installers from the cache to free space"
+    WScript.Echo "  -f/--force             Install even if the version appears to be installed already"
+    WScript.Echo "  -s/--skip-existing     Skip the installation if the version appears to be installed already"
+    WScript.Echo "  -r/--register          Register version for py launcher"
+    WScript.Echo "  -q/--quiet             Install using /quiet. This does not show the UI nor does it prompt for inputs"
+    WScript.Echo "  --32only               Installs only 32bit Python using -a/--all switch, no effect on 32-bit windows."
+    WScript.Echo "  --64only               Installs only 64bit Python using -a/--all switch, no effect on 32-bit windows."
+    WScript.Echo "  --dev                  Installs precompiled standard libraries, debug symbols, and debug binaries (only applies to web installer)."
+    WScript.Echo "  --help                 Help, list of options allowed on pyenv install"
     WScript.Echo ""
     WScript.Quit
 End Sub
@@ -334,22 +335,24 @@ Sub main(arg)
 
     For idx = 0 To arg.Count - 1
         Select Case arg(idx)
-            Case "--help"       ShowHelp
-            Case "-l"           optList = True
-            Case "--list"       optList = True
-            Case "-f"           optForce = True
-            Case "--force"      optForce = True
-            Case "-q"           optQuiet = True
-            Case "--quiet"      optQuiet = True
-            Case "-a"           optAll = True
-            Case "--all"        optAll = True
-            Case "-c"           optClear = True
-            Case "--clear"      optClear = True
-            Case "--32only"     opt32 = True
-            Case "--64only"     opt64 = True
-            Case "--dev"        optDev = True
-            Case "-r"           optReg = True
-            Case "--register"   optReg = True
+            Case "--help"           ShowHelp
+            Case "-l"               optList = True
+            Case "--list"           optList = True
+            Case "-f"               optForce = True
+            Case "--force"          optForce = True
+            Case "-s"               optForce = False
+            Case "--skip-existing"  optForce = False
+            Case "-q"               optQuiet = True
+            Case "--quiet"          optQuiet = True
+            Case "-a"               optAll = True
+            Case "--all"            optAll = True
+            Case "-c"               optClear = True
+            Case "--clear"          optClear = True
+            Case "--32only"         opt32 = True
+            Case "--64only"         opt64 = True
+            Case "--dev"            optDev = True
+            Case "-r"               optReg = True
+            Case "--register"       optReg = True
             Case Else
                 installVersions.Item(Check32Bit(arg(idx))) = Empty
         End Select


### PR DESCRIPTION
For `pyenv` CLI compatibility, since [it is a supported option there](https://github.com/pyenv/pyenv/blame/master/COMMANDS.md#L208).

This is basically the same as #314 with a subtle difference: Here I'm not creating a new (unused) option, but just using the existing `optForce` and setting it to `False` when this flag is provided. I believe this is a more correct way of accomplishing the same.

As this is done by default, nothing should change besides the fact that now `pyenv-win`'s CLI is more similar to `pyenv`. Previous invocations with `-f` and `-s` would have failed, whereas now they will just act as if `-f` is not present.

I've stumbled upon this while working on a fix for this [pipenv issue](https://github.com/pypa/pipenv/issues/4525), as mentioned in #314. Fixing the root issue there brought me upon this one, and while it's true that it could be fixed by just removing the `-s` flag from pipenv's invocation (since it's the default behaviour), I thought it might still be interesting to add this just for compatibility with the original `pyenv`.

Thank you for your time and don't hesitate to share your thoughts, I'll respond as quickly as I can!