### PR TITLE
`pyenv exec` executes the scripts inside %AppData%/Python/PythonVersion/Scripts.

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -22,6 +22,19 @@ set "bindir="
 set "extrapaths="
 for /f "%skip_arg%delims=" %%i in ('%pyenv% vname') do call :extrapath "%~dp0..\versions\%%i"
 
+:: Add %AppData% Python Scripts to %extrapaths%.
+for /F "tokens=1,2 delims=-" %%i in ('%pyenv% vname') do (
+  if /i "%%j" == "win32" (
+    for /F "tokens=1,2,3 delims=." %%a in ("%%i") do (
+        set "extrapaths=%extrapaths%%AppData%\Python\Python%%a%%b-32\Scripts;"
+    )
+  ) else (
+     for /F "tokens=1,2,3 delims=." %%a in ("%%i") do (
+        set "extrapaths=%extrapaths%%AppData%\Python\Python%%a%%b\Scripts;"
+    )
+  )
+)
+
 :: all help implemented as plugin
 if /i [%2]==[--help] goto :plugin
 if /i [%1]==[--help] (


### PR DESCRIPTION
* Closes #233 
* Closes #218
* Closes #202

When installing packages with `pip`, they're installed inside `%AppData%/Python/PythonVersion/Scripts.`

`pyenv` currently doesn't add that path to `%extrapaths%`, so it cannot find commands installed by `pip`. 

This PR fixes this problem. 

* **Before**: `pyenv exec pipenv install` -> Fail.
* **After**: `pyenv exec pipenv install` -> Works.
