### PR TITLE
Fix 417: CMD file redirect operators inside a quoted string break things

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -71,8 +71,8 @@ if not exist "%bindir%" (
   exit /b
 )
 
-set "cmdline=%*"
-set "cmdline=%cmdline:~5%"
+set cmdline=%*
+set cmdline=%cmdline:~5%
 
 :: update PATH to active version and run command
 :: endlocal needed only if cmdline sets a variable: SET FOO=BAR
@@ -148,9 +148,9 @@ if exist "%exe%.bat" (
 )
 
 :: replace first arg with %exe%
-set "cmdline=%*"
-set "cmdline=%cmdline:^=^^%"
-set "cmdline=%cmdline:!=^!%"
+set cmdline=%*
+set cmdline=%cmdline:^=^^%
+set cmdline=%cmdline:!=^!%
 set "arg1=%1"
 set "len=1"
 :loop_len
@@ -159,7 +159,7 @@ set "arg1=%arg1:~1%"
 if not [%arg1%]==[] goto :loop_len
 
 setlocal enabledelayedexpansion
-set "cmdline=!exe! !cmdline:~%len%!"
+set cmdline=!exe! !cmdline:~%len%!
 :: run command (no need to update PATH for plugins)
 :: endlocal needed to ensure exit will not automatically close setlocal
 :: otherwise PYTHON_VERSION will be lost


### PR DESCRIPTION
I was too enthusiastic when I was improving support for spaces

Fixes #417