### PR TITLE
Bug fix: folder.Name is invalid, because folder is a string

### DIFF
--- a/pyenv-win/libexec/pyenv-uninstall.vbs
+++ b/pyenv-win/libexec/pyenv-uninstall.vbs
@@ -121,7 +121,7 @@ Sub main(arg)
             If IsVersion(folder) And objfs.FolderExists(uninstallPath) Then
                 objfs.DeleteFolder uninstallPath, optForce
                 If Err.Number <> 0 Then
-                    WScript.Echo "pyenv: Error ("& Err.Number &") uninstalling version "& folder.Name &": "& Err.Description
+                    WScript.Echo "pyenv: Error ("& Err.Number &") uninstalling version "& folder &": "& Err.Description
                     Err.Clear
                     delError = 1
                 Else


### PR DESCRIPTION
Very simple bug fix, for uninstall script, when there is an error it was using `folder.Name`, but `folder` is a string, there is no `Name` property.