### PR TITLE
fix Chocolatey installation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Currently we support following ways, choose any of your comfort:
 - [Git Commands](#git-commands) - default way + adding manual settings
 - [Pyenv-win zip](#pyenv-win-zip) - manual installation
 - [Python pip](#python-pip) - for existing users
-- [Chocolatey](#Chocolatey)
+- [Chocolatey](#chocolatey)
 - [How to use 32-train](#how-to-use-32-train)  
    - [check announcements](#Announcements)
 


### PR DESCRIPTION
The link in the *Installation* section to the Chocolatey instructions was broken in the rendered HTML.

For GitHub Pages the on-page anchor links need to be lowercase. This isn't well documented but when testing in both chromium and firefox browsers, changing the inner-link from (#Chocolatey) -> (#chocolatey) fixed the broken link.