### PR TITLE
install-pyenv-win: select correct Expand-Archive

### DIFF
--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -117,7 +117,7 @@ Function Main() {
     $DownloadPath = "$PyEnvDir\pyenv-win.zip"
 
     (New-Object System.Net.WebClient).DownloadFile("https://github.com/pyenv-win/pyenv-win/archive/master.zip", $DownloadPath)
-    Expand-Archive -Path $DownloadPath -DestinationPath $PyEnvDir
+    Microsoft.PowerShell.Archive\Expand-Archive -Path $DownloadPath -DestinationPath $PyEnvDir
     Move-Item -Path "$PyEnvDir\pyenv-win-master\*" -Destination "$PyEnvDir"
     Remove-Item -Path "$PyEnvDir\pyenv-win-master" -Recurse
     Remove-Item -Path $DownloadPath


### PR DESCRIPTION
Expand-Archive on a user's pc might have been set to PSCX version instead of from the default Module: Microsoft.PowerShell.Archive.

In that case, the install script will error out saying "Expand-Archive : A parameter cannot be found that matches parameter name 'DestinationPath'."

To force script to use correct version of Expand-Archive, the script should prepend the module name in front of the command