### PR TITLE
Remove > from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project was forked from [rbenv-win][3] and modified for [pyenv][1]. It is n
 1. Install pyenv-win in PowerShell.
 
    ```pwsh
-   > Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
+   Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
    ```
 
 2. Reopen PowerShell


### PR DESCRIPTION
Using the built-in copy link on the readme copies the `>` too.  
This makes the command invalid `> : The term '>' is not recognized as the name of a cmdlet...`