### PR TITLE
updating docs, to resolve misleading of pyenv commands

### DIFF
--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -162,12 +162,14 @@ Function GetCurrentVersion()
     Dim str
     str = GetCurrentVersionNoError
     If IsNull(str) Then
-		WScript.echo "No global/local python version has been set yet. Please set the global/local version by typing:"
-		WScript.echo "pyenv global 3.7.4"
-        WScript.echo "pyenv local 3.7.4"
-    WScript.quit 1
-	End If
-	GetCurrentVersion = str
+        WScript.echo "No global/local python version has been set yet. Please set the global/local version by typing:"
+        WScript.echo "pyenv global <python-version>"
+        WScript.echo "pyenv global 3.7.4"
+        WScript.echo "pyenv global <python-version>"
+        WScript.echo "pyenv global 3.7.4"
+        WScript.quit 1
+    End If
+    GetCurrentVersion = str
 End Function
 
 Function GetCurrentVersionNoError()
@@ -184,12 +186,14 @@ Function GetCurrentVersions()
     Dim versions
     Set versions = GetCurrentVersionsNoError
     If versions.Count = 0 Then
-		WScript.echo "No global/local python version has been set yet. Please set the global/local version by typing:"
-		WScript.echo "pyenv global 3.7.4"
+        WScript.echo "No global/local python version has been set yet. Please set the global/local version by typing:"
+        WScript.echo "pyenv global <python-version>"
+        WScript.echo "pyenv global 3.7.4"
+        WScript.echo "pyenv local <python-version>"
         WScript.echo "pyenv local 3.7.4"
-    WScript.quit 1
-	End If
-	Set GetCurrentVersions = versions
+        WScript.quit 1
+    End If
+    Set GetCurrentVersions = versions
 End Function
 
 Function GetCurrentVersionsNoError()

--- a/tests/test_pyenv_feature_version.py
+++ b/tests/test_pyenv_feature_version.py
@@ -24,7 +24,9 @@ def test_no_version(pyenv):
         (
             "No global/local python version has been set yet. "
             "Please set the global/local version by typing:\r\n"
+            "pyenv global <python-version>\r\n"
             "pyenv global 3.7.4\r\n"
+            "pyenv local <python-version>\r\n"
             "pyenv local 3.7.4"
         ),
         ""

--- a/tests/test_pyenv_feature_version_name.py
+++ b/tests/test_pyenv_feature_version_name.py
@@ -31,7 +31,9 @@ def test_no_version(command, pyenv):
         (
             "No global/local python version has been set yet. "
             "Please set the global/local version by typing:\r\n"
+            "pyenv global <python-version>\r\n"
             "pyenv global 3.7.4\r\n"
+            "pyenv local <python-version>\r\n"
             "pyenv local 3.7.4"
         ),
         ""

--- a/tests/test_pyenv_feature_which.py
+++ b/tests/test_pyenv_feature_which.py
@@ -147,7 +147,9 @@ def test_which_no_version_defined(pyenv):
             (
                 "No global/local python version has been set yet. "
                 "Please set the global/local version by typing:\r\n"
+                "pyenv global <python-version>\r\n"
                 "pyenv global 3.7.4\r\n"
+                "pyenv local <python-version>\r\n"
                 "pyenv local 3.7.4"
             ),
             ""


### PR DESCRIPTION
updating docs, to resolve misleading of pyenv commands
```
No global/local python version has been set yet. Please set the global/local version by typing:
pyenv global <python-version>
pyenv global 3.7.4
pyenv local <python-version>
pyenv local 3.7.4
```