### PR TITLE
rolling back to resolve instant issues about lnk files

### DIFF
--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -388,6 +388,8 @@ Sub Rehash()
                 baseName = objfs.GetBaseName(file)
                 If LCase(objfs.GetExtensionName(file)) <> "exe" Then
                     LinkExeFiles baseName, file
+                    WriteWinScript baseName
+                    WriteLinuxScript baseName
                 Else
                     WriteWinScript baseName
                     WriteLinuxScript baseName


### PR DESCRIPTION
As per the feedback we got from @ddspj23 we are rolling back to old state, but keeping the lnk files, but they are not going to use/called in the pyenv.bat file