### PR TITLE
Bug Fix: Replaced "$LastExitCode" with "$?"

### DIFF
--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -76,7 +76,7 @@ Function Get-LatestVersion() {
 Function Main() {
     If ($Uninstall) {
         Remove-PyEnv
-        If ($LastExitCode -eq 0) {
+        If ($? -eq $True) {
             Write-Host "pyenv-win successfully uninstalled."
         }
         Else {
@@ -140,7 +140,7 @@ Function Main() {
         Move-Item -Path "$BackupDir/*" -Destination $PyEnvWinDir
     }
     
-    If ($LastExitCode -eq 0) {
+    If ($? -eq $True) {
         Write-Host "pyenv-win is successfully installed. You may need to close and reopen your terminal before using it."
     }
     Else {


### PR DESCRIPTION
Replacing the conditional `$LastExitCode -eq 0` with `$? -eq $True` because the value of `$LastExitCode` is NULL (empty). This is happening because `$LastExitCode` is only set by executables or batch files when they return. PowerShell commands can be checked with `$?`  ([reference](https://stackoverflow.com/a/16722912)) This is causing false-negatives, telling users that the installation/uninstallation is failing, when in reality it is succeeding.

This should resolve issue https://github.com/pyenv-win/pyenv-win/issues/424.