### PR TITLE
Update pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: pytest bash script
         run: ${{ env.HOME }}/.github/scripts/build.sh


### PR DESCRIPTION
Node.js 12 actions are deprecated. Updating the `actions/checkout` GitHub action to Node.js 16.

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/