### PR TITLE
Curl fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ This PC
 
 **NOTE:** If you are running Windows 10 1905 or newer, you might need to disable the built-in Python launcher via Start > "Manage App Execution Aliases" and turning off the "App Installer" aliases for Python
 
+### `WinHTTP` errors in certain environments
+
+There may be cases, such as on a corporate network, that communications via [`WinHTTPRequest`](https://learn.microsoft.com/en-us/windows/win32/winhttp/winhttprequest) may fail. 
+In that case, if [cURL](https://curl.se/windows/) is in your `PATH`, pyenv can use it as a fallback.
+
 ## Usage
 
 - To view a list of python versions supported by pyenv windows: `pyenv install -l`

--- a/pyenv-win/libexec/pyenv-update.vbs
+++ b/pyenv-win/libexec/pyenv-update.vbs
@@ -82,26 +82,48 @@ End Sub
 
 Function ScanForVersions(URL, optIgnore, ByRef pageCount)
     Dim objHTML
+    Dim shell
+    Dim cmd
+    Dim msg
+    Dim result
     Set objHTML = CreateObject("htmlfile")
+    Set shell = CreateObject("WScript.Shell")
     Set ScanForVersions = CreateObject("Scripting.Dictionary")
 
     With objweb
-        .open "GET", URL, False
         On Error Resume Next
+        .open "GET", URL, False
+        .Option(WinHttpRequestSslErrorFlags_SslErrorFlag_Ignore_All) = true
         .send
         If Err.number <> 0 Then
-            WScript.Echo "HTTP Error downloading from mirror page """& URL &""""& vbCrLf &"Error(0x"& Hex(Err.Number) &"): "& Err.Description
+            msg = "HTTP Error downloading on send from mirror page """& URL &""""& vbCrLf &"Error(0x"& Hex(Err.Number) &"): "& Err.Description
+            Err.clear
+            cmd = "cmd /c curl -L " & URL
+            'WScript.Echo "    Failed to download via WinHTTP, attempting cURL"
+            'WScript.Echo "    cURL command: """& cmd &""""
+            Set result = shell.Exec(cmd)
+            If Err.number = 0 Then
+                'WScript.Echo "    cURL did not error, using cURL's output"
+                'WScript.Echo "    cURL output: "
+                'WScript.Echo result.stdOut.ReadAll
+                'WScript.Echo "^^^ cURL output ^^^"
+                objHTML.write result.StdOut.ReadAll
+                'WScript.Echo "    cURL succeeded getting """& objHTML.title &""""
+            End If
+            If Err.number <> 0 Then
+                WScript.Echo msg & ", and attempting to fall back to a system cURL call failed ("& Err.number &"): "& Err.Description
+                If optIgnore Then Exit Function
+                WScript.Quit 1
+            End If
+            On Error GoTo 0
+        ElseIf .Status <> 200 Then
+            WScript.Echo "HTTP Status Error downloading from version page """& URL &""""& vbCrLf &"Error("& .Status &"): "& .StatusText
             If optIgnore Then Exit Function
             WScript.Quit 1
-        End If
-        On Error GoTo 0
-        If .status <> 200 Then
-            WScript.Echo "HTTP Error downloading from mirror page """& URL &""""& vbCrLf &"Error("& .status &"): "& .statusText
-            If optIgnore Then Exit Function
-            WScript.Quit 1
+        Else
+            objHTML.write .responseText
         End If
 
-        objHTML.write .responseText
         pageCount = pageCount + 1
     End With
     EnsureBaseURL objHTML, URL
@@ -250,35 +272,58 @@ Sub main(arg)
 
     Dim objHTML
     Dim pageCount
+    Dim shell
+    Dim cmd
+    Dim msg
+    Dim result
     Set objHTML = CreateObject("htmlfile")
+    Set shell = CreateObject("WScript.Shell")
     pageCount = 0
-
     With objweb
         On Error Resume Next
         .Open "GET", mirror, False
         If Err.number <> 0 Then
+            WScript.Echo "Raw open err != 0 "& Err.number
             WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
             If optIgnore Then Exit Sub
             WScript.Quit 1
         End If
+
+        .Option(WinHttpRequestSslErrorFlags_SslErrorFlag_Ignore_All) = true
 
         .Send
         If Err.number <> 0 Then
-            WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
-            If optIgnore Then Exit Sub
-            WScript.Quit 1
-        End If
-        On Error GoTo 0
-
-        If .Status <> 200 Then
+            msg = "HTTP Error (send) downloading from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
+            Err.clear
+            cmd = "cmd /c curl -L " & mirror
+            'WScript.Echo "    Failed to update from WinHTTP, attempting cURL"
+            'WScript.Echo "    cURL command: """& cmd &""""
+            Set result = shell.Exec(cmd)
+            If Err.number = 0 Then
+                'WScript.Echo "    cURL did not error, using cURL's output"
+                'WScript.Echo "    cURL output: "
+                'WScript.Echo result.stdOut.ReadAll
+                'WScript.Echo "^^^ cURL output ^^^"
+                objHTML.write result.StdOut.ReadAll
+                WScript.Echo "    cURL succeeded getting """& objHTML.title &""""
+            End If
+            If Err.number <> 0 Then
+                WScript.Echo msg & ", and attempting to fall back to a system cURL call failed ("& Err.number &"): "& Err.Description
+                If optIgnore Then Exit Sub
+                WScript.Quit 1
+            End If
+            On Error GoTo 0
+        ElseIf .Status <> 200 Then
             WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error("& .Status &"): "& .StatusText
             If optIgnore Then Exit Sub
             WScript.Quit 1
+        Else
+            objHTML.write .responseText
         End If
 
-        objHTML.write .responseText
         pageCount = pageCount + 1
     End With
+
     EnsureBaseURL objHTML, mirror
 
     Dim link


### PR DESCRIPTION
Corporate machines on our network can't use WinHTTPRequest, always raising `Error(0x80072EFD): A connection with the server could not be established`. 

This PR adds a fallback when updating the database or downloading the install, attempting to use a system version of cURL if installed. A note about this and a link to the Windows binaries of cURL was added to the README.

This works for our team, but we also couldn't test that this PR didn't break the primary path, so you guys should _not_ blindly merge this PR. 

Thanks for a great tool for our workflow, guys!