### PR TITLE
feature: pyenv migrate

### DIFF
--- a/pyenv-win/libexec/pyenv-migrate.bat
+++ b/pyenv-win/libexec/pyenv-migrate.bat
@@ -1,0 +1,22 @@
+@echo off
+setlocal
+
+if [%1] == [] goto :help_menu
+if "%1" == "--help" goto :help_menu
+
+set T=%TIME::=%
+set TMP_FILE=pyenv_requirements_%T: =%.tmp
+
+if not exist "%PYENV%versions\%1\" echo Python %1 does not exist & exit /b
+if not exist "%PYENV%versions\%2\" echo Python %2 does not exist & exit /b
+
+cmd /c "pyenv shell %1 & pip freeze > "%TMP%\%TMP_FILE%""
+cmd /c "pyenv shell %2 & pip install -r "%TMP%\%TMP_FILE%""
+cmd /c "pyenv rehash & del "%TMP%\%TMP_FILE%""
+exit /b
+
+:help_menu
+echo Usage: pyenv migrate ^<from^> ^<to^>
+echo    ex. pyenv migrate 3.8.10 3.11.4
+echo.
+echo Migrate pip packages from a Python version to another.

--- a/pyenv-win/libexec/pyenv-migrate.bat
+++ b/pyenv-win/libexec/pyenv-migrate.bat
@@ -10,9 +10,12 @@ set TMP_FILE=pyenv_requirements_%T: =%.tmp
 if not exist "%PYENV%versions\%1\" echo Python %1 does not exist & exit /b
 if not exist "%PYENV%versions\%2\" echo Python %2 does not exist & exit /b
 
+setlocal
+set PIP_REQUIRE_VIRTUALENV=0
 cmd /c "pyenv shell %1 & pip freeze > "%TMP%\%TMP_FILE%""
 cmd /c "pyenv shell %2 & pip install -r "%TMP%\%TMP_FILE%""
 cmd /c "pyenv rehash & del "%TMP%\%TMP_FILE%""
+endlocal
 exit /b
 
 :help_menu


### PR DESCRIPTION
I have implemented the `migrate` command, which has the same usage as the original [pyenv/pyenv-pip-migrate](https://github.com/pyenv/pyenv-pip-migrate).

The only change is the batch script file I added to the libexec directory. It does not conflict with other functionality, so it should be fine to be merged. I also tested it with the batch files `tests\bat_files\test_install.bat` and `tests\bat_files\test_uninstall.bat`, as suggested in the 'How to contribute' section.

If there is anything that needs to be modified, let me know.