### PR TITLE
Migrate all PIP package from one to another python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This PC
   - _Note: The version must first be installed._
 - After (un)installing any libraries using pip or modifying the files in a version's folder, you must run `pyenv rehash` to update pyenv with new shims for the python and libraries' executables.
   - _Note: This must be run outside of the `.pyenv` folder._
+- After installing a clean new Python version you may install a copy of all PIP packages used in earler Python versions by running `pyenv migrate <source-version> <destination-version>`.
 - To uninstall a python version: `pyenv uninstall 3.5.2`
 - To view which python you are using and its path: `pyenv version`
 - To view all the python versions installed on this system: `pyenv versions`

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -48,7 +48,7 @@ if /i [%1]==[help] (
 )
 
 :: let pyenv.vbs handle these
-set "commands=rehash global local version vname version-name versions commands shims which whence help --help"
+set "commands=rehash global local migrate version vname version-name versions commands shims which whence help --help"
 for %%a in (%commands%) do (
   if /i [%1]==[%%a] (
     rem endlocal not really needed here since above commands do not set any variable

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -371,6 +371,40 @@ Sub WriteLinuxScript(baseName)
     End If
 End Sub
 
+' Run external process
+' Param command: string, command to be executed
+' Param printOutput: optional bool, Print process output to console
+' Param shell: optional WScript.Shell, The shell object to be used to run the command
+' Return stdout of the process
+Function Execute(command, printOutput, shell)
+    Dim process, output, fullOutput
+    fullOutput = ""
+    output = ""
+
+    If IsNull(printOutput) Then
+        printOutput = true
+    End If
+    If IsNull(shell) Then
+        Set shell = WScript.CreateObject("WScript.Shell")
+    End If
+    
+    Set process = shell.Exec(command)
+    Do While True
+        If Not process.StdOut.AtEndOfStream Then
+            output = process.StdOut.Read(1024)
+            If printOutput Then
+                WScript.Echo output
+            End If
+            fullOutput = fullOutput & output
+        End If
+        If process.Status = 1 Then
+            Exit Do
+        End If
+        WScript.Sleep 100
+    Loop
+    Execute = fullOutput
+End Function
+
 ' pyenv rehash
 Sub Rehash()
     ' WScript.echo "kkotari: pyenv-lib.vbs pyenv rehash..!"

--- a/pyenv-win/libexec/pyenv-migrate.bat
+++ b/pyenv-win/libexec/pyenv-migrate.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal
+
+if "%1" == "--help" (
+echo Usage: pyenv migrate ^<source-version^> ^<destination-version^>
+echo.
+echo Install all PIP packages from source version in destination version.
+echo. 
+echo For example::
+echo   pyenv migrate 3.8.5 3.11.0
+echo.
+EXIT /B
+)
+
+:: Implementation of this command is in the pyenv.vbs file


### PR DESCRIPTION
This PR adds a new subcommand `migrate` to install all PIP packages from one to another Python version. It's inspired by [pyenv-pip-migrate plugin](https://github.com/pyenv/pyenv-pip-migrate/tree/master).

Usage example:

```
>pyenv migrate 3.11.0 3.9.0
certifi==2024.2.2
charset-normalizer==3.3.2
idna==3.6
requests==2.31.0
urllib3==2.2.1

Collecting certifi==2024.2.2
  Using cached certifi-2024.2.2-py3-none-any.whl (163 kB)
Collecting charset-normalizer==3.3.2
  Downloading charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl (100 kB)
Collecting idna==3.6
  Using cached idna-3.6-py3-none-any.whl (61 kB)
Collecting requests==2.31.0
  Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Collecting urllib3==2.2.1
  Using cached urllib3-2.2.1-py3-none-any.whl (121 kB)
Installing collected packages: certifi, charset-normalizer, idna, urllib3, requests
Successfully installed certifi-2024.2.2 charset-normalizer-3.3.2 idna-3.6 requests-2.31.0 urllib3-2.2.1

>
```