### PR TITLE
(#601) Fix `install-pyenv-win.ps1` for Windows Docker

### DIFF
--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -117,7 +117,12 @@ Function Main() {
     $DownloadPath = "$PyEnvDir\pyenv-win.zip"
 
     (New-Object System.Net.WebClient).DownloadFile("https://github.com/pyenv-win/pyenv-win/archive/master.zip", $DownloadPath)
-    Microsoft.PowerShell.Archive\Expand-Archive -Path $DownloadPath -DestinationPath $PyEnvDir
+
+    Start-Process -FilePath "powershell.exe" -ArgumentList @(
+        "-NoProfile",
+        "-Command `"Microsoft.PowerShell.Archive\Expand-Archive -Path $DownloadPath -DestinationPath $PyEnvDir`""
+    ) -NoNewWindow -Wait
+
     Move-Item -Path "$PyEnvDir\pyenv-win-master\*" -Destination "$PyEnvDir"
     Remove-Item -Path "$PyEnvDir\pyenv-win-master" -Recurse
     Remove-Item -Path $DownloadPath


### PR DESCRIPTION
Fixes #601 

This commit makes sure that `Expand-Archive` finished before attempting to move or remove the contents extracted.

---
To test things out, you can reproduce the bug as described in https://github.com/pyenv-win/pyenv-win/issues/601 and then:
1. Remove the broken `pyenv` installation:
```sh-session
rm -Force -Recurse C:\Users\ContainerAdministrator\.pyenv
```
2. Try these changes:
```sh-session
Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/luchihoratiu/pyenv-win/bug/install-pyenv-win.ps1_fails_in_windows_docker/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
```
---
![image](https://github.com/pyenv-win/pyenv-win/assets/39198766/fb213d81-4fa5-4110-bf5a-9ca2b0f0a7ea)
Note: I also installed [Chocolatey](https://chocolatey.org/install) and ran `Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1` to make the `refreshenv` command available.