### PR TITLE
Fix problems with pyenv installed via scoop.

### DIFF
--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -126,6 +126,8 @@ Function deepExtract(params, web)
     Dim msi
     For Each file In objfs.GetFolder(cachePath).Files
         baseName = LCase(objfs.GetBaseName(file))
+        file = getRealPath(file) ' Get the real path to the file.
+        installPath = getRealPath(installPath) ' Get the real path to the install path.
         deepExtract = objws.Run("msiexec /quiet /a """& file &""" TargetDir="""& installPath & """", 0, True)
         If deepExtract Then
             WScript.Echo ":: [Error] :: error installing """& baseName &""" component MSI."


### PR DESCRIPTION
pyenv installed via scoop cannot install python correctly due to the use of juntionpoints in the scoop shims as [discussed here](https://github.com/pyenv-win/pyenv-win/issues/449). I fix the problems by getting the real path before executing msiexec program.
	
- modified:   pyenv-win/libexec/libs/pyenv-install-lib.vbs
    Add a function called getRealPath to get the real path of a path containing junctionpoint.

- modified:   pyenv-win/libexec/pyenv-install.vbs
    Call the function above to get the real path of a cached msi file and the real path of installing target folder.