### PR TITLE
Fix bug: PowerShell installation failed when the installation path contains space

### DIFF
--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -120,7 +120,7 @@ Function Main() {
 
     Start-Process -FilePath "powershell.exe" -ArgumentList @(
         "-NoProfile",
-        "-Command `"Microsoft.PowerShell.Archive\Expand-Archive -Path $DownloadPath -DestinationPath $PyEnvDir`""
+        "-Command `"Microsoft.PowerShell.Archive\Expand-Archive -Path \`"$DownloadPath\`" -DestinationPath \`"$PyEnvDir\`"`""
     ) -NoNewWindow -Wait
 
     Move-Item -Path "$PyEnvDir\pyenv-win-master\*" -Destination "$PyEnvDir"


### PR DESCRIPTION
- Solved issue: https://github.com/pyenv-win/pyenv-win/issues/617
- Tested the changes by `running tests\bat_files\test_install.bat` and `tests\bat_files\test_uninstall.bat`

