### PR TITLE
Re-add PyPy (got lost when automating the version cache) and add GraalPy

### DIFF
--- a/pyenv-win/.versions_cache.xml
+++ b/pyenv-win/.versions_cache.xml
@@ -3520,4 +3520,262 @@
 		<file>python-3.13.0b2-amd64.exe</file>
 		<URL>https://www.python.org/ftp/python/3.13.0/python-3.13.0b2-amd64.exe</URL>
 	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.7-v7.3.4-win64</code>
+		<file>pypy3.7-v7.3.4-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.7-v7.3.4-win64.zip</URL>
+		<zipRootDir>pypy3.7-v7.3.4-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.4-win64</code>
+		<file>pypy2.7-v7.3.4-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.4-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.4-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.7-v7.3.5-win64</code>
+		<file>pypy3.7-v7.3.5-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.7-v7.3.5-win64.zip</URL>
+		<zipRootDir>pypy3.7-v7.3.5-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.5-win64</code>
+		<file>pypy2.7-v7.3.5-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.5-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.5-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.8-v7.3.6-win64</code>
+		<file>pypy3.8-v7.3.6-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.8-v7.3.6-win64.zip</URL>
+		<zipRootDir>pypy3.8-v7.3.6-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.7-v7.3.6-win64</code>
+		<file>pypy3.7-v7.3.6-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.7-v7.3.6-win64.zip</URL>
+		<zipRootDir>pypy3.7-v7.3.6-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.6-win64</code>
+		<file>pypy2.7-v7.3.6-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.6-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.6-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.8-v7.3.7-win64</code>
+		<file>pypy3.8-v7.3.7-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.8-v7.3.7-win64.zip</URL>
+		<zipRootDir>pypy3.8-v7.3.7-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.7-v7.3.7-win64</code>
+		<file>pypy3.7-v7.3.7-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.7-v7.3.7-win64.zip</URL>
+		<zipRootDir>pypy3.7-v7.3.7-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.8-v7.3.8-win64</code>
+		<file>pypy3.8-v7.3.8-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.8-v7.3.8-win64.zip</URL>
+		<zipRootDir>pypy3.8-v7.3.8-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.8-win64</code>
+		<file>pypy3.9-v7.3.8-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.8-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.8-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.8-win64</code>
+		<file>pypy2.7-v7.3.8-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.8-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.8-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.7-v7.3.8-win64</code>
+		<file>pypy3.7-v7.3.8-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip</URL>
+		<zipRootDir>pypy3.7-v7.3.8-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.8-v7.3.9-win64</code>
+		<file>pypy3.8-v7.3.9-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip</URL>
+		<zipRootDir>pypy3.8-v7.3.9-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.9-win64</code>
+		<file>pypy3.9-v7.3.9-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.9-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.9-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.9-win64</code>
+		<file>pypy2.7-v7.3.9-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.9-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.9-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.7-v7.3.9-win64</code>
+		<file>pypy3.7-v7.3.9-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.7-v7.3.9-win64.zip</URL>
+		<zipRootDir>pypy3.7-v7.3.9-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.8-v7.3.10-win64</code>
+		<file>pypy3.8-v7.3.10-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.8-v7.3.10-win64.zip</URL>
+		<zipRootDir>pypy3.8-v7.3.10-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.10-win64</code>
+		<file>pypy3.9-v7.3.10-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.10-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.10-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.10-win64</code>
+		<file>pypy2.7-v7.3.10-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.10-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.10-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.11-win64</code>
+		<file>pypy3.9-v7.3.11-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.11-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.11-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.8-v7.3.11-win64</code>
+		<file>pypy3.8-v7.3.11-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.8-v7.3.11-win64.zip</URL>
+		<zipRootDir>pypy3.8-v7.3.11-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.11-win64</code>
+		<file>pypy2.7-v7.3.11-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.11-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.11-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.10-v7.3.12-win64</code>
+		<file>pypy3.10-v7.3.12-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.10-v7.3.12-win64.zip</URL>
+		<zipRootDir>pypy3.10-v7.3.12-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.12-win64</code>
+		<file>pypy3.9-v7.3.12-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.12-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.12-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.12-win64</code>
+		<file>pypy2.7-v7.3.12-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.12-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.12-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.10-v7.3.13-win64</code>
+		<file>pypy3.10-v7.3.13-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.10-v7.3.13-win64.zip</URL>
+		<zipRootDir>pypy3.10-v7.3.13-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.13-win64</code>
+		<file>pypy3.9-v7.3.13-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.13-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.13-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.13-win64</code>
+		<file>pypy2.7-v7.3.13-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.13-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.13-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.10-v7.3.14-win64</code>
+		<file>pypy3.10-v7.3.14-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.10-v7.3.14-win64.zip</URL>
+		<zipRootDir>pypy3.10-v7.3.14-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.14-win64</code>
+		<file>pypy3.9-v7.3.14-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.14-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.14-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.14-win64</code>
+		<file>pypy2.7-v7.3.14-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.14-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.14-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.10-v7.3.15-win64</code>
+		<file>pypy3.10-v7.3.15-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.10-v7.3.15-win64.zip</URL>
+		<zipRootDir>pypy3.10-v7.3.15-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.15-win64</code>
+		<file>pypy3.9-v7.3.15-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.15-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.15-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.15-win64</code>
+		<file>pypy2.7-v7.3.15-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.15-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.15-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.10-v7.3.16-win64</code>
+		<file>pypy3.10-v7.3.16-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.10-v7.3.16-win64.zip</URL>
+		<zipRootDir>pypy3.10-v7.3.16-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy3.9-v7.3.16-win64</code>
+		<file>pypy3.9-v7.3.16-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy3.9-v7.3.16-win64.zip</URL>
+		<zipRootDir>pypy3.9-v7.3.16-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>pypy2.7-v7.3.16-win64</code>
+		<file>pypy2.7-v7.3.16-win64.zip</file>
+		<URL>https://downloads.python.org/pypy/pypy2.7-v7.3.16-win64.zip</URL>
+		<zipRootDir>pypy2.7-v7.3.16-win64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>graalpy-23.1.0-windows-amd64</code>
+		<file>graalpy-23.1.0-windows-amd64.zip</file>
+		<URL>https://github.com/oracle/graalpython/releases/download/graal-23.1.0/graalpy-23.1.0-windows-amd64.zip</URL>
+		<zipRootDir>graalpy-23.1.0-windows-amd64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>graalpy-23.1.1-windows-amd64</code>
+		<file>graalpy-23.1.1-windows-amd64.zip</file>
+		<URL>https://github.com/oracle/graalpython/releases/download/graal-23.1.1/graalpy-23.1.1-windows-amd64.zip</URL>
+		<zipRootDir>graalpy-23.1.1-windows-amd64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>graalpy-23.1.2-windows-amd64</code>
+		<file>graalpy-23.1.2-windows-amd64.zip</file>
+		<URL>https://github.com/oracle/graalpython/releases/download/graal-23.1.2/graalpy-23.1.2-windows-amd64.zip</URL>
+		<zipRootDir>graalpy-23.1.2-windows-amd64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>graalpy-24.0.0-windows-amd64</code>
+		<file>graalpy-24.0.0-windows-amd64.zip</file>
+		<URL>https://github.com/oracle/graalpython/releases/download/graal-24.0.0/graalpy-24.0.0-windows-amd64.zip</URL>
+		<zipRootDir>graalpy-24.0.0-windows-amd64</zipRootDir>
+	</version>
+	<version x64="true" webInstall="false" msi="false">
+		<code>graalpy-24.0.1-windows-amd64</code>
+		<file>graalpy-24.0.1-windows-amd64.zip</file>
+		<URL>https://github.com/oracle/graalpython/releases/download/graal-24.0.1/graalpy-24.0.1-windows-amd64.zip</URL>
+		<zipRootDir>graalpy-24.0.1-windows-amd64</zipRootDir>
+	</version>
 </versions>

--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -177,7 +177,7 @@ goto :eof
 :: compute list of paths to add for all activated python versions
 :extrapath
 call :normalizepath %1 bindir
-set "extrapaths=%extrapaths%%bindir%;%bindir%\Scripts;"
+set "extrapaths=%extrapaths%%bindir%;%bindir%\Scripts;%bindir%\bin;"
 goto :eof
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: check pyenv python shim is first in PATH

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -406,20 +406,23 @@ Sub Rehash()
             End If
         Next
 
-        If objfs.FolderExists(winBinDir & "\Scripts") Then
-            For Each file In objfs.GetFolder(winBinDir & "\Scripts").Files
-                ' WScript.echo "kkotari: pyenv-lib.vbs rehash for winBinDir\Scripts"
-                If exts.Exists(LCase(objfs.GetExtensionName(file))) Then
-                    baseName = objfs.GetBaseName(file)
-                    If LCase(objfs.GetExtensionName(file)) <> "exe" Then
-                        LinkExeFiles baseName, file
-                    Else
-                        WriteWinScript baseName
-                        WriteLinuxScript baseName
+        Dim subDir
+        For Each subDir in Array("\Scripts", "\bin")
+            If objfs.FolderExists(winBinDir & subDir) Then
+                For Each file In objfs.GetFolder(winBinDir & subDir).Files
+                    ' WScript.echo "kkotari: pyenv-lib.vbs rehash for winBinDir\Scripts"
+                    If exts.Exists(LCase(objfs.GetExtensionName(file))) Then
+                        baseName = objfs.GetBaseName(file)
+                        If LCase(objfs.GetExtensionName(file)) <> "exe" Then
+                            LinkExeFiles baseName, file
+                        Else
+                            WriteWinScript baseName
+                            WriteLinuxScript baseName
+                        End If
                     End If
-                End If
-            Next
-        End If
+                Next
+            End If
+        Next
     Next
 End Sub
 

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -16,7 +16,10 @@ End Sub
 Import "libs\pyenv-lib.vbs"
 Import "libs\pyenv-install-lib.vbs"
 
-WScript.Echo ":: [Info] ::  Mirror: " & mirror
+Dim mirror
+For Each mirror In mirrors
+    WScript.Echo ":: [Info] ::  Mirror: " & mirror
+Next
 
 Sub ShowHelp()
     ' WScript.echo "kkotari: pyenv-install.vbs..!"

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -138,19 +138,22 @@ Sub CommandWhich(arg)
             End If
         Next
 
-        If objfs.FolderExists(strDirVers &"\"& version & "\Scripts") Then
-            If objfs.FileExists(strDirVers &"\"& version &"\Scripts\"& program) Then
-                WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\Scripts\"& program).Path
-                WScript.Quit 0
-            End If
-
-            For Each ext In exts.Keys
-                If objfs.FileExists(strDirVers &"\"& version &"\Scripts\"& program & ext) Then
-                    WScript.Echo objfs.GetFile(strDirVers &"\"& version &"\Scripts\"& program & ext).Path
+        Dim subDir
+        For Each subDir in Array("\Scripts", "\bin")
+            If objfs.FolderExists(strDirVers &"\"& version & subDir) Then
+                If objfs.FileExists(strDirVers &"\"& version & subDir &"\"& program) Then
+                    WScript.Echo objfs.GetFile(strDirVers &"\"& version & subDir &"\"& program).Path
                     WScript.Quit 0
                 End If
-            Next
-        End If
+
+                For Each ext In exts.Keys
+                    If objfs.FileExists(strDirVers &"\"& version & subDir &"\"& program & ext) Then
+                        WScript.Echo objfs.GetFile(strDirVers &"\"& version & subDir &"\"& program & ext).Path
+                        WScript.Quit 0
+                    End If
+                Next
+            End If
+        Next
     Next
 
     WScript.Echo "pyenv: "& arg(1) &": command not found"
@@ -224,31 +227,34 @@ Sub CommandWhence(arg)
             Next
         End If
 
-        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
-            If objfs.FileExists(dir & "\Scripts\" & program) Then
-                found = True
-                foundAny = 0
-                If isPath Then
-                    WScript.Echo objfs.GetFile(dir & "\Scripts\" & program).Path
-                Else
-                    WScript.Echo objfs.GetFileName( dir )
-                End If
-            End If
-        End If
-
-        If Not found Or isPath And objfs.FolderExists(dir & "\Scripts") Then
-            For Each ext In exts.Keys
-                If objfs.FileExists(dir & "\Scripts\" & program & ext) Then
+        Dim subDir
+        For Each subDir in Array("\Scripts", "\bin")
+            If Not found Or isPath And objfs.FolderExists(dir & subDir) Then
+                If objfs.FileExists(dir & subDir &"\" & program) Then
+                    found = True
                     foundAny = 0
                     If isPath Then
-                        WScript.Echo objfs.GetFile(dir & "\Scripts\" & program & ext).Path
+                        WScript.Echo objfs.GetFile(dir & subDir & "\" & program).Path
                     Else
                         WScript.Echo objfs.GetFileName( dir )
                     End If
-                    Exit For
                 End If
-            Next
-        End If
+            End If
+
+            If Not found Or isPath And objfs.FolderExists(dir & subDir) Then
+                For Each ext In exts.Keys
+                    If objfs.FileExists(dir & subDir & "\" & program & ext) Then
+                        foundAny = 0
+                        If isPath Then
+                            WScript.Echo objfs.GetFile(dir & subDir & "\" & program & ext).Path
+                        Else
+                            WScript.Echo objfs.GetFileName( dir )
+                        End If
+                        Exit For
+                    End If
+                Next
+            End If
+        Next
     Next
 
     WScript.Quit foundAny

--- a/tests/test_pyenv_feature_exec.py
+++ b/tests/test_pyenv_feature_exec.py
@@ -130,8 +130,10 @@ def test_many_paths(pyenv_path, env, pyenv):
         (
             rf"{pyenv_path}\versions\{Native('3.7.7')};"
             rf"{pyenv_path}\versions\{Native('3.7.7')}\Scripts;"
+            rf"{pyenv_path}\versions\{Native('3.7.7')}\bin;"
             rf"{pyenv_path}\versions\{Native('3.8.9')};"
             rf"{pyenv_path}\versions\{Native('3.8.9')}\Scripts;"
+            rf"{pyenv_path}\versions\{Native('3.8.9')}\bin;"
         )
     )
     assert pyenv.exec('version.bat') == ("3.7.7", "")

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -30,6 +30,8 @@ def test_check_pyenv_install_list(pyenv):
     assert "3.9.0" in result
     assert "3.9.1-win32" in result
     assert "3.9.1" in result
+    assert "graalpy" in result
+    assert "pypy" in result
 
 
 def test_check_pyenv_installation():


### PR DESCRIPTION
https://github.com/pyenv-win/pyenv-win/pull/238 added PyPy, but that got lost when updating the versions cache. I extended the script to update the cache to update also PyPy versions and added GraalPy.

![image](https://github.com/pyenv-win/pyenv-win/assets/46235/28e29f5e-de76-4d6b-ad64-6e9cf2e97ebe)

There's a bug in GraalPy which makes a simple `graalpy` invocation not work, but `pyenv exec graalpy.exe` works (the GraalPy bug is that the launcher assumes the command that started it must end with `.exe` on Windows and it crashes hard when it doesn't)