### PR TITLE
Fix errors in registry entries created when python is installed with `--register`

### DIFF
--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -249,7 +249,7 @@ Sub registerVersion(version, installPath)
     key = "HKCU\SOFTWARE\Python\PythonCore\"
     ' I prefer not overriding default Python registry values (that might already exist)
     ' Python Software Foundation
-    'sh.RegWrite key & "DiplayName","pyenv-win","REG_SZ"
+    'sh.RegWrite key & "DisplayName","pyenv-win","REG_SZ"
     ' http://www.python.org/
     'sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
     key = key & version &"\"

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -236,6 +236,15 @@ Sub registerVersion(version, installPath)
     sysVersion = parts(0) &"."& parts(1)
     featureVersion = parts(0) &"."& parts(1) &"."& parts(2) &".0"
 
+    dim bitDepth
+
+    If InStr(version, "-win32") Then
+        bitDepth = "32"
+        version = Replace(version, "-win32", "")
+    Else
+        bitDepth = "64"
+    End If     
+
     key = "HKCU\SOFTWARE\Python\PythonCore\"
     ' I prefer not overriding default Python registry values (that might already exist)
     ' Python Software Foundation
@@ -243,9 +252,9 @@ Sub registerVersion(version, installPath)
     ' http://www.python.org/
     'sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
     key = key & version &"\"
-    sh.RegWrite key & "DiplayName","Python "& sysVersion &" (64-bit)","REG_SZ"
+    sh.RegWrite key & "DiplayName","Python "& sysVersion &" (" & bitDepth & "-bit)","REG_SZ"
     sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
-    sh.RegWrite key & "SysArchitecture","64bit","REG_SZ"
+    sh.RegWrite key & "SysArchitecture",bitDepth & "bit","REG_SZ"
     sh.RegWrite key & "SysVersion",sysVersion,"REG_SZ"
     sh.RegWrite key & "Version",version,"REG_SZ"
     ' python only (not pypy)

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -236,13 +236,14 @@ Sub registerVersion(version, installPath)
     sysVersion = parts(0) &"."& parts(1)
     featureVersion = parts(0) &"."& parts(1) &"."& parts(2) &".0"
 
-    dim bitDepth
+    dim bitDepth, versionAttribute
 
     If InStr(version, "-win32") Then
         bitDepth = "32"
-        version = Replace(version, "-win32", "")
+        versionAttribute = Replace(version, "-win32", "")
     Else
         bitDepth = "64"
+        versionAttribute = version
     End If     
 
     key = "HKCU\SOFTWARE\Python\PythonCore\"
@@ -256,7 +257,7 @@ Sub registerVersion(version, installPath)
     sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
     sh.RegWrite key & "SysArchitecture",bitDepth & "bit","REG_SZ"
     sh.RegWrite key & "SysVersion",sysVersion,"REG_SZ"
-    sh.RegWrite key & "Version",version,"REG_SZ"
+    sh.RegWrite key & "Version",versionAttribute,"REG_SZ"
     ' python only (not pypy)
     subKey = key & "InstalledFeatures\"
     sh.RegWrite subKey & "dev",featureVersion,"REG_SZ"

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -253,7 +253,7 @@ Sub registerVersion(version, installPath)
     ' http://www.python.org/
     'sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
     key = key & version &"\"
-    sh.RegWrite key & "DiplayName","Python "& sysVersion &" (" & bitDepth & "-bit)","REG_SZ"
+    sh.RegWrite key & "DisplayName","Python "& sysVersion &" (" & bitDepth & "-bit)","REG_SZ"
     sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
     sh.RegWrite key & "SysArchitecture",bitDepth & "bit","REG_SZ"
     sh.RegWrite key & "SysVersion",sysVersion,"REG_SZ"


### PR DESCRIPTION
Fixes for #656 

Fix typo in the registry entry names:

* 'DiplayName' is corrected to 'DisplayName' (missing 's')

Correctly identifies 32-bit Python installed on a 64-bit machine:

* 'DisplayName' will now show '(32-bit)' instead of '(64-bit)' for 32 bit installs
* 'SysArchitecture' will now show '32bit' instead of '64bit' for 32 bit installs
* 'Version' no longer includes '-win32' for 32 bit installs
* **'Company' and 'Tag' are unchanged**
  * eg a 32 bit Python 3.12.5 install will still be under `PythonCore\3.12.5-win32` as it was before.

These changes match the values you get if you install 32 bit python for the current user through the python.org installers (apart from pyenv-win using the 3 part version number and `-win32` instead of `-32`  in the 'Tag').