### PR TITLE
Set exit code when executing local-not-installed version

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -68,7 +68,7 @@ if not exist "%bindir%" (
   echo No global/local python version has been set yet. Please set the global/local version by typing:
   echo pyenv global 3.7.4
   echo pyenv local 3.7.4
-  exit /b
+  exit /b 1
 )
 
 set cmdline=%*

--- a/tests/test_pyenv_feature_exec.py
+++ b/tests/test_pyenv_feature_exec.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import pytest
 from pathlib import Path
@@ -137,6 +138,16 @@ def test_many_paths(pyenv_path, env, pyenv):
         )
     )
     assert pyenv.exec('version.bat') == ("3.7.7", "")
+
+
+@pytest.mark.parametrize('settings', [lambda: {
+        'versions': [],
+        'local_ver': Native('3.8.5')
+    }])
+def test_exec_local_not_installed(pyenv):
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        pyenv.exec('python', check=True)
+    assert e.value.returncode == 1
 
 
 def test_bat_shim(pyenv):


### PR DESCRIPTION
If you git checkout a branch that changes local .python-version to something you don't have, right now `python ...` prints an error message but "succeeds"--it doesn't set any exit code.

Fix `pyenv exec ...` to exit with code 1 (same as pyenv on *nix)

Tested with unit test. Manually validated that python shim preserves exit code

## Summary by Sourcery

Ensure that executing a local-not-installed Python version exits with code 1 by modifying the pyenv script and adding a corresponding test.

Bug Fixes:
- Fix the issue where executing a local-not-installed Python version does not set an exit code, ensuring it exits with code 1.

Tests:
- Add a test to verify that executing a local-not-installed Python version raises a subprocess.CalledProcessError with exit code 1.