### PR TITLE
Improve wording for error message

### DIFF
--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -100,7 +100,7 @@ Function deepExtract(params, web)
             End If
             deepExtract = objws.Run("cmd /D /C move """& cachePath &"""\AttachedContainer\*.msi """& cachePath &"""", 0, True)
             If deepExtract Then
-                WScript.Echo ":: [Error] :: error extracting the embedded portion from the installer."
+                WScript.Echo ":: [Error] :: error moving the extracted embedded portion from the installer."
                 Exit Function
             End If
         End If


### PR DESCRIPTION
This error message previously had the exact same text as the previous error, which meant that if one of these commands failed it would be difficult for the user to figure out which one was at fault.

## Summary by Sourcery

Enhancements:
- Update error message to specify failure in moving the extracted installer portion.