### PR TITLE
This PR is to resolve #702

### DIFF
--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -420,8 +420,8 @@ Sub CommandShell(arg)
             ReDim shellVersions(versionCount - 1)
             Dim i
             For i = 0 To versionCount - 1
-                shellVersions(i) = Check32Bit(arg(i + 1))
-                GetBinDir(shellVersions(i))
+                shellVersions(i) = arg(i + 1)
+                GetBinDir(TryResolveVersion(shellVersions(i), False))
             Next
         End If
 


### PR DESCRIPTION
Change "pyenv shell" command behavior according to issues/702
Allow pinning Python versions without specifying a patch version