### PR TITLE
Add support for downloading MSI files from mirror sources

### DIFF
--- a/pyenv-win/bin/pyenv.bat
+++ b/pyenv-win/bin/pyenv.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-chcp 65001 >nul 2>&1
+chcp 1250 >nul
 
 set "pyenv=cscript //nologo "%~dp0..\libexec\pyenv.vbs""
 
@@ -48,7 +48,7 @@ if /i [%1]==[help] (
 )
 
 :: let pyenv.vbs handle these
-set "commands=rehash global local version vname version-name versions commands shims which whence help --help"
+set "commands=rehash global local version vname version-name versions commands shims which whence help --help --version"
 for %%a in (%commands%) do (
   if /i [%1]==[%%a] (
     rem endlocal not really needed here since above commands do not set any variable
@@ -68,11 +68,11 @@ if not exist "%bindir%" (
   echo No global/local python version has been set yet. Please set the global/local version by typing:
   echo pyenv global 3.7.4
   echo pyenv local 3.7.4
-  exit /b 1
+  exit /b
 )
 
-set cmdline=%*
-set cmdline=%cmdline:~5%
+set "cmdline=%*"
+set "cmdline=%cmdline:~5%"
 
 :: update PATH to active version and run command
 :: endlocal needed only if cmdline sets a variable: SET FOO=BAR
@@ -142,17 +142,15 @@ if exist "%exe%.bat" (
 ) else if exist "%exe%.vbs" (
   set "exe=cscript //nologo "%exe%.vbs""
 
-) else if exist "%exe%.lnk" (
-  set "exe=start '' "%exe%.bat""
 ) else (
   echo pyenv: no such command '%1'
   exit /b 1
 )
 
 :: replace first arg with %exe%
-set cmdline=%*
-set cmdline=%cmdline:^=^^%
-set cmdline=%cmdline:!=^!%
+set "cmdline=%*"
+set "cmdline=%cmdline:^=^^%"
+set "cmdline=%cmdline:!=^!%"
 set "arg1=%1"
 set "len=1"
 :loop_len
@@ -161,7 +159,7 @@ set "arg1=%arg1:~1%"
 if not [%arg1%]==[] goto :loop_len
 
 setlocal enabledelayedexpansion
-set cmdline=!exe! !cmdline:~%len%!
+set "cmdline=!exe! !cmdline:~%len%!"
 :: run command (no need to update PATH for plugins)
 :: endlocal needed to ensure exit will not automatically close setlocal
 :: otherwise PYTHON_VERSION will be lost
@@ -177,7 +175,7 @@ goto :eof
 :: compute list of paths to add for all activated python versions
 :extrapath
 call :normalizepath %1 bindir
-set "extrapaths=%extrapaths%%bindir%;%bindir%\Scripts;%bindir%\bin;"
+set "extrapaths=%extrapaths%%bindir%;%bindir%\Scripts;"
 goto :eof
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: check pyenv python shim is first in PATH

--- a/pyenv-win/bin/pyenv.ps1
+++ b/pyenv-win/bin/pyenv.ps1
@@ -1,4 +1,3 @@
-$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
 If (($Args.Count -ge 2) -and ($Args[0] -eq "shell")) {
     if ($Args[1] -eq "--help") {

--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -76,7 +76,7 @@ Function Get-LatestVersion() {
 Function Main() {
     If ($Uninstall) {
         Remove-PyEnv
-        If ($? -eq $True) {
+        If ($LastExitCode -eq 0) {
             Write-Host "pyenv-win successfully uninstalled."
         }
         Else {
@@ -117,12 +117,7 @@ Function Main() {
     $DownloadPath = "$PyEnvDir\pyenv-win.zip"
 
     (New-Object System.Net.WebClient).DownloadFile("https://github.com/pyenv-win/pyenv-win/archive/master.zip", $DownloadPath)
-
-    Start-Process -FilePath "powershell.exe" -ArgumentList @(
-        "-NoProfile",
-        "-Command `"Microsoft.PowerShell.Archive\Expand-Archive -Path \`"$DownloadPath\`" -DestinationPath \`"$PyEnvDir\`"`""
-    ) -NoNewWindow -Wait
-
+    Expand-Archive -Path $DownloadPath -DestinationPath $PyEnvDir
     Move-Item -Path "$PyEnvDir\pyenv-win-master\*" -Destination "$PyEnvDir"
     Remove-Item -Path "$PyEnvDir\pyenv-win-master" -Recurse
     Remove-Item -Path $DownloadPath
@@ -145,7 +140,7 @@ Function Main() {
         Move-Item -Path "$BackupDir/*" -Destination $PyEnvWinDir
     }
     
-    If ($? -eq $True) {
+    If ($LastExitCode -eq 0) {
         Write-Host "pyenv-win is successfully installed. You may need to close and reopen your terminal before using it."
     }
     Else {

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -19,6 +19,9 @@ Else
 End If
 On Error GoTo 0
 
+Dim mirror
+mirror = mirrors(0)
+
 Const SFV_FileName = 0
 Const SFV_URL = 1
 Const SFV_Version = 2
@@ -28,12 +31,16 @@ Const VRX_Minor = 1
 Const VRX_Patch = 2
 Const VRX_Release = 3
 Const VRX_RelNumber = 4
-Const VRX_x64 = 5
-Const VRX_ARM = 6
-Const VRX_Web = 7
-Const VRX_Ext = 8
-Const VRX_Arch = 5
-Const VRX_ZipRoot = 9
+Const VRX_Embeddable = 5
+Const VRX_Embed = 6
+Const VRX_Test = 7
+Const VRX_x64 = 8
+Const VRX_ARM = 9
+Const VRX_Win32 = 10
+Const VRX_Web = 11
+Const VRX_Ext = 12
+Const VRX_Arch = 8
+Const VRX_ZipRoot = 13
 
 ' Version definition array from LoadVersionsXML.
 Const LV_Code = 0
@@ -60,17 +67,17 @@ Set regexVerArch = New RegExp
 Set regexFile = New RegExp
 Set regexJsonUrl = New RegExp
 With regexVer
-    .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?$"
+    .Pattern = "^(\d+)\.(\d+)(?:\.(\d+))?([a-z]+(\d*))?$"
     .Global = True
     .IgnoreCase = True
 End With
 With regexVerArch
-    .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?([\.-](?:amd64|arm64|win32))?$"
+    .Pattern = "^(\d+)\.(\d+)(?:\.(\d+))?([a-z]+(\d*))?([\.-](?:amd64|arm64|win32))?$"
     .Global = True
     .IgnoreCase = True
 End With
 With regexFile
-    .Pattern = "^python-(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?([\.-]amd64)?([\.-]arm64)?(-webinstall)?\.(exe|msi)$"
+    .Pattern = "^python-(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?(?:(-embeddable)|(-embed)|(-test))?([\.-]amd64)?([\.-]arm64)?([\.-]win32)?(-webinstall)?\.(exe|msi|zip)$"
     .Global = True
     .IgnoreCase = True
 End With
@@ -84,33 +91,44 @@ End With
 
 ' Adding -win32 as a post fix for x86 Arch
 Function JoinWin32String(pieces)
-    ' WScript.echo "kkotari: pyenv-install-lib.vbs JoinWin32String..!"
     JoinWin32String = ""
-    If Len(pieces(VRX_Major))     Then JoinWin32String = JoinWin32String & pieces(VRX_Major)
-    If Len(pieces(VRX_Minor))     Then JoinWin32String = JoinWin32String &"."& pieces(VRX_Minor)
-    If Len(pieces(VRX_Patch))     Then JoinWin32String = JoinWin32String &"."& pieces(VRX_Patch)
-    If Len(pieces(VRX_Release))   Then JoinWin32String = JoinWin32String & pieces(VRX_Release)
-    If Len(pieces(VRX_RelNumber)) Then JoinWin32String = JoinWin32String & pieces(VRX_RelNumber)
-    If Len(pieces(VRX_ARM)) Then
+    If Not IsArray(pieces) Or UBound(pieces) < 0 Then Exit Function
+    On Error Resume Next
+    If UBound(pieces) >= VRX_Major And Len(pieces(VRX_Major)) Then JoinWin32String = JoinWin32String & pieces(VRX_Major)
+    If UBound(pieces) >= VRX_Minor And Len(pieces(VRX_Minor)) Then JoinWin32String = JoinWin32String &"."& pieces(VRX_Minor)
+    If UBound(pieces) >= VRX_Patch And Len(pieces(VRX_Patch)) Then JoinWin32String = JoinWin32String &"."& pieces(VRX_Patch)
+    If UBound(pieces) >= VRX_Release And Len(pieces(VRX_Release)) Then JoinWin32String = JoinWin32String & pieces(VRX_Release)
+    If UBound(pieces) >= VRX_RelNumber And Len(pieces(VRX_RelNumber)) Then JoinWin32String = JoinWin32String & pieces(VRX_RelNumber)
+    If UBound(pieces) >= VRX_ARM And Len(pieces(VRX_ARM)) Then
         JoinWin32String = JoinWin32String & "-arm"
-    ElseIf Len(pieces(VRX_x64)) = 0 Then
+    ElseIf UBound(pieces) >= VRX_x64 And Len(pieces(VRX_x64)) = 0 Then
         JoinWin32String = JoinWin32String & "-win32"
     End If
+    If Err.Number <> 0 Then Err.Clear
+    On Error GoTo 0
 End Function
 
 ' For x64 Arch
 Function JoinInstallString(pieces)
-    ' WScript.echo "kkotari: pyenv-install-lib.vbs JoinInstallString..!"
     JoinInstallString = ""
-    If Len(pieces(VRX_Major))     Then JoinInstallString = JoinInstallString & pieces(VRX_Major)
-    If Len(pieces(VRX_Minor))     Then JoinInstallString = JoinInstallString &"."& pieces(VRX_Minor)
-    If Len(pieces(VRX_Patch))     Then JoinInstallString = JoinInstallString &"."& pieces(VRX_Patch)
-    If Len(pieces(VRX_Release))   Then JoinInstallString = JoinInstallString & pieces(VRX_Release)
-    If Len(pieces(VRX_RelNumber)) Then JoinInstallString = JoinInstallString & pieces(VRX_RelNumber)
-    If Len(pieces(VRX_x64))       Then JoinInstallString = JoinInstallString & pieces(VRX_x64)
-    If Len(pieces(VRX_ARM))       Then JoinInstallString = JoinInstallString & pieces(VRX_ARM)
-    If Len(pieces(VRX_Web))       Then JoinInstallString = JoinInstallString & pieces(VRX_Web)
-    If Len(pieces(VRX_Ext))       Then JoinInstallString = JoinInstallString &"."& pieces(VRX_Ext)
+    If Not IsArray(pieces) Or UBound(pieces) < 0 Then Exit Function
+    On Error Resume Next
+    If UBound(pieces) >= VRX_Major And Len(pieces(VRX_Major)) Then JoinInstallString = JoinInstallString & pieces(VRX_Major)
+    If UBound(pieces) >= VRX_Minor And Len(pieces(VRX_Minor)) Then JoinInstallString = JoinInstallString &"."& pieces(VRX_Minor)
+    If UBound(pieces) >= VRX_Patch And Len(pieces(VRX_Patch)) Then JoinInstallString = JoinInstallString &"."& pieces(VRX_Patch)
+    If UBound(pieces) >= VRX_Release And Len(pieces(VRX_Release)) Then JoinInstallString = JoinInstallString & pieces(VRX_Release)
+    If UBound(pieces) >= VRX_RelNumber And Len(pieces(VRX_RelNumber)) Then JoinInstallString = JoinInstallString & pieces(VRX_RelNumber)
+    If UBound(pieces) >= VRX_Embeddable And Len(pieces(VRX_Embeddable)) Then JoinInstallString = JoinInstallString & pieces(VRX_Embeddable)
+    If UBound(pieces) >= VRX_Embed And Len(pieces(VRX_Embed)) Then JoinInstallString = JoinInstallString & pieces(VRX_Embed)
+    If UBound(pieces) >= VRX_Test And Len(pieces(VRX_Test)) Then JoinInstallString = JoinInstallString & pieces(VRX_Test)
+    If UBound(pieces) >= VRX_x64 And Len(pieces(VRX_x64)) Then JoinInstallString = JoinInstallString & pieces(VRX_x64)
+    If UBound(pieces) >= VRX_ARM And Len(pieces(VRX_ARM)) Then JoinInstallString = JoinInstallString & pieces(VRX_ARM)
+    If UBound(pieces) >= VRX_Win32 And Len(pieces(VRX_Win32)) Then JoinInstallString = JoinInstallString & pieces(VRX_Win32)
+    If UBound(pieces) >= VRX_Web And Len(pieces(VRX_Web)) Then JoinInstallString = JoinInstallString & pieces(VRX_Web)
+    If UBound(pieces) >= VRX_Ext And Len(pieces(VRX_Ext)) Then JoinInstallString = JoinInstallString &"."& pieces(VRX_Ext)
+    If UBound(pieces) >= VRX_ZipRoot And Len(pieces(VRX_ZipRoot)) Then JoinInstallString = JoinInstallString & pieces(VRX_ZipRoot)
+    If Err.Number <> 0 Then Err.Clear
+    On Error GoTo 0
 End Function
 
 ' Download exe file
@@ -118,28 +136,49 @@ Function DownloadFile(strUrl, strFile)
     ' WScript.echo "kkotari: pyenv-install-lib.vbs DownloadFile..!"
     On Error Resume Next
 
-    objweb.Open "GET", strUrl, False
-    If Err.Number <> 0 Then
-        WScript.Echo ":: [ERROR] :: "& Err.Description
-        WScript.Quit 1
+    ' Try using PowerShell first (most reliable)
+    Dim psCmd
+    psCmd = "powershell -ExecutionPolicy Bypass -Command ""$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '" & strUrl & "' -OutFile '" & strFile & "' -UserAgent 'pyenv-win'"""
+    objws.Run psCmd, 0, True
+
+    If Err.Number = 0 And objfs.FileExists(strFile) Then
+        Dim fileSize
+        fileSize = objfs.GetFile(strFile).Size
+        If fileSize > 1000 Then
+            Exit Function
+        End If
     End If
 
-    objweb.Send
-    If Err.Number <> 0 Then
-        WScript.Echo ":: [ERROR] :: "& Err.Description
-        WScript.Quit 1
-    End If
-    On Error GoTo 0
+    ' Fallback to bitsadmin
+    Err.Clear
+    Dim bitsCmd
+    bitsCmd = "bitsadmin /transfer python /priority high /timeout 300 """ & strUrl & """ """ & strFile & """"
+    objws.Run bitsCmd, 0, True
 
-    If objweb.Status <> 200 Then
-        WScript.Echo ":: [ERROR] :: "& objweb.Status &" :: "& objweb.StatusText
+    If Err.Number = 0 And objfs.FileExists(strFile) Then
+        fileSize = objfs.GetFile(strFile).Size
+        If fileSize > 1000 Then
+            Exit Function
+        End If
+    End If
+
+    ' Last resort: VBS HTTP
+    Err.Clear
+    Dim webObj
+    Set webObj = CreateObject("MSXML2.XMLHTTP")
+    webObj.Open "GET", strUrl, False
+    webObj.SetRequestHeader "User-Agent", "Mozilla/5.0 (compatible; pyenv-win)"
+    webObj.SetRequestHeader "Accept", "*/*"
+    webObj.Send
+    If webObj.Status <> 200 Then
+        WScript.Echo ":: [ERROR] :: HTTP "& webObj.Status &" :: "& webObj.StatusText
         WScript.Quit 1
     End If
 
     With CreateObject("ADODB.Stream")
         .Open
         .Type = 1
-        .Write objweb.responseBody
+        .Write webObj.responseBody
         .SaveToFile strFile, 2
         .Close
     End With
@@ -257,32 +296,46 @@ End Function
 
 ' Append new version to DB
 Sub SaveVersionsXML(xmlPath, versArray)
-    ' WScript.echo "kkotari: pyenv-install-lib.vbs SaveVersionsXML..!"
     Dim doc
     Set doc = CreateObject("Msxml2.DOMDocument.6.0")
     Set doc.documentElement = doc.createElement("versions")
 
     Dim versRow
     Dim versElem
+    On Error Resume Next
     For Each versRow In versArray
         Set versElem = doc.createElement("version")
         doc.documentElement.appendChild versElem
 
         With versElem
-            .setAttribute "x64",        LocaleIndependantCStr(CBool(Len(versRow(SFV_Version)(VRX_x64)) OR Len(versRow(SFV_Version)(VRX_ARM))))
-            .setAttribute "webInstall", LocaleIndependantCStr(CBool(Len(versRow(SFV_Version)(VRX_Web))))
-            .setAttribute "msi",        LocaleIndependantCStr(LCase(versRow(SFV_Version)(VRX_Ext)) = "msi")
+            If UBound(versRow(SFV_Version)) >= VRX_Ext Then
+                .setAttribute "x64",        LocaleIndependantCStr(CBool(Len(versRow(SFV_Version)(VRX_x64)) OR Len(versRow(SFV_Version)(VRX_ARM))))
+                .setAttribute "webInstall", LocaleIndependantCStr(CBool(Len(versRow(SFV_Version)(VRX_Web))))
+                .setAttribute "msi",        LocaleIndependantCStr(LCase(versRow(SFV_Version)(VRX_Ext)) = "msi")
+            End If
         End With
-        If versRow(SFV_Version)(VRX_Ext) = "zip" Then
-            AppendElement doc, versElem, "code", versRow(SFV_Version)(VRX_ZipRoot)
-        Else
-            AppendElement doc, versElem, "code", JoinWin32String(versRow(SFV_Version))
+        If UBound(versRow(SFV_Version)) >= VRX_Ext Then
+            If versRow(SFV_Version)(VRX_Ext) = "zip" Then
+                ' For zip files, if ZipRoot is set use it, otherwise use JoinWin32String
+                If UBound(versRow(SFV_Version)) >= VRX_ZipRoot And Len(versRow(SFV_Version)(VRX_ZipRoot)) > 0 Then
+                    AppendElement doc, versElem, "code", versRow(SFV_Version)(VRX_ZipRoot)
+                Else
+                    AppendElement doc, versElem, "code", JoinWin32String(versRow(SFV_Version))
+                End If
+            Else
+                AppendElement doc, versElem, "code", JoinWin32String(versRow(SFV_Version))
+            End If
         End If
         AppendElement doc, versElem, "file", versRow(0)
         AppendElement doc, versElem, "URL", versRow(1)
-        If versRow(SFV_Version)(VRX_Ext) = "zip" Then
-            AppendElement doc, versElem, "zipRootDir", versRow(SFV_Version)(VRX_ZipRoot)
+        If UBound(versRow(SFV_Version)) >= VRX_Ext Then
+            If versRow(SFV_Version)(VRX_Ext) = "zip" Then
+                If UBound(versRow(SFV_Version)) >= VRX_ZipRoot Then
+                    AppendElement doc, versElem, "zipRootDir", versRow(SFV_Version)(VRX_ZipRoot)
+                End If
+            End If
         End If
+        If Err.Number <> 0 Then Err.Clear
     Next
 
     ' Use SAXXMLReader/MXXMLWriter to "pretty print" the XML data.
@@ -310,85 +363,130 @@ Sub SaveVersionsXML(xmlPath, versArray)
         .putProperty "http://xml.org/sax/properties/lexical-handler", writer
         .parse doc
     End With
+    On Error Resume Next
+    ' Delete old file first to avoid any conflicts
+    If objfs.FileExists(xmlPath) Then
+        objfs.DeleteFile xmlPath, True
+        If Err.Number <> 0 Then Err.Clear
+    End If
+
     With outXML
-        .SaveToFile xmlpath, 2
+        .SaveToFile xmlPath, 2
+        If Err.Number <> 0 Then
+            Err.Clear
+            ' Try alternative: save directly from doc
+            doc.save xmlPath
+            If Err.Number <> 0 Then
+                WScript.Echo ":: [Error] :: Failed to save database: "& Err.Description
+                Err.Clear
+            End If
+        End If
         .Close
     End With
+    On Error GoTo 0
 End Sub
 
 ' Test if ver1 < ver2
 Function SymanticCompare(ver1, ver2)
     Dim comp1, comp2
 
-    ' Major
-    comp1 = ver1(VRX_Major)
-    comp2 = ver2(VRX_Major)
-    If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
-    If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
-
-    ' Minor
-    comp1 = ver1(VRX_Minor)
-    comp2 = ver2(VRX_Minor)
-    If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
-    If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
-
-    ' Patch
-    comp1 = ver1(VRX_Patch)
-    comp2 = ver2(VRX_Patch)
-    If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
-    If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
-
-    ' Release
-    comp1 = ver1(VRX_Release)
-    comp2 = ver2(VRX_Release)
-    If Len(comp1) = 0 And Len(comp2) Then
+    ' Safety check for empty arrays
+    If Not IsArray(ver1) Or Not IsArray(ver2) Then
         SymanticCompare = False
         Exit Function
-    ElseIf Len(comp1) And Len(comp2) = 0 Then
-        SymanticCompare = True
-        Exit Function
-    Else
-        SymanticCompare = comp1 < comp2
     End If
-    If comp1 <> comp2 Then Exit Function
+    If UBound(ver1) < 0 Or UBound(ver2) < 0 Then
+        SymanticCompare = False
+        Exit Function
+    End If
+
+    ' Major
+    If UBound(ver1) >= VRX_Major And UBound(ver2) >= VRX_Major Then
+        comp1 = ver1(VRX_Major)
+        comp2 = ver2(VRX_Major)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Minor
+    If UBound(ver1) >= VRX_Minor And UBound(ver2) >= VRX_Minor Then
+        comp1 = ver1(VRX_Minor)
+        comp2 = ver2(VRX_Minor)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Patch
+    If UBound(ver1) >= VRX_Patch And UBound(ver2) >= VRX_Patch Then
+        comp1 = ver1(VRX_Patch)
+        comp2 = ver2(VRX_Patch)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Release
+    If UBound(ver1) >= VRX_Release And UBound(ver2) >= VRX_Release Then
+        comp1 = ver1(VRX_Release)
+        comp2 = ver2(VRX_Release)
+        If Len(comp1) = 0 And Len(comp2) Then
+            SymanticCompare = False
+            Exit Function
+        ElseIf Len(comp1) And Len(comp2) = 0 Then
+            SymanticCompare = True
+            Exit Function
+        Else
+            SymanticCompare = comp1 < comp2
+        End If
+        If comp1 <> comp2 Then Exit Function
+    End If
 
     ' Release Number
-    comp1 = ver1(VRX_RelNumber)
-    comp2 = ver2(VRX_RelNumber)
-    If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
-    If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
+    If UBound(ver1) >= VRX_RelNumber And UBound(ver2) >= VRX_RelNumber Then
+        comp1 = ver1(VRX_RelNumber)
+        comp2 = ver2(VRX_RelNumber)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
 
     ' x64
-    comp1 = ver1(VRX_x64)
-    comp2 = ver2(VRX_x64)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
+    If UBound(ver1) >= VRX_x64 And UBound(ver2) >= VRX_x64 Then
+        comp1 = ver1(VRX_x64)
+        comp2 = ver2(VRX_x64)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
 
     ' ARM
-    comp1 = ver1(VRX_ARM)
-    comp2 = ver2(VRX_ARM)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
+    If UBound(ver1) >= VRX_ARM And UBound(ver2) >= VRX_ARM Then
+        comp1 = ver1(VRX_ARM)
+        comp2 = ver2(VRX_ARM)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
 
     ' webinstall
-    comp1 = ver1(VRX_Web)
-    comp2 = ver2(VRX_Web)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
+    If UBound(ver1) >= VRX_Web And UBound(ver2) >= VRX_Web Then
+        comp1 = ver1(VRX_Web)
+        comp2 = ver2(VRX_Web)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
 
     ' ext
-    comp1 = ver1(VRX_Ext)
-    comp2 = ver2(VRX_Ext)
-    SymanticCompare = comp1 < comp2
-    If comp1 <> comp2 Then Exit Function
+    If UBound(ver1) >= VRX_Ext And UBound(ver2) >= VRX_Ext Then
+        comp1 = ver1(VRX_Ext)
+        comp2 = ver2(VRX_Ext)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
 End Function
 
 ' Modified from code by "Reverend Jim" at:
@@ -439,12 +537,13 @@ End Sub
 Function JoinVersionString(pieces)
     ' WScript.echo "kkotari: pyenv-install-lib.vbs JoinVersionString..!"
     JoinVersionString = ""
-    If Len(pieces(VRX_Major))     Then JoinVersionString = JoinVersionString & pieces(VRX_Major)
-    If Len(pieces(VRX_Minor))     Then JoinVersionString = JoinVersionString &"."& pieces(VRX_Minor)
-    If Len(pieces(VRX_Patch))     Then JoinVersionString = JoinVersionString &"."& pieces(VRX_Patch)
-    If Len(pieces(VRX_Release))   Then JoinVersionString = JoinVersionString & pieces(VRX_Release)
-    If Len(pieces(VRX_RelNumber)) Then JoinVersionString = JoinVersionString & pieces(VRX_RelNumber)
-    If Len(pieces(VRX_Arch))      Then JoinVersionString = JoinVersionString & pieces(VRX_Arch)
+    If Not IsArray(pieces) Or UBound(pieces) < 0 Then Exit Function
+    If UBound(pieces) >= VRX_Major And Len(pieces(VRX_Major)) Then JoinVersionString = JoinVersionString & pieces(VRX_Major)
+    If UBound(pieces) >= VRX_Minor And Len(pieces(VRX_Minor)) Then JoinVersionString = JoinVersionString &"."& pieces(VRX_Minor)
+    If UBound(pieces) >= VRX_Patch And Len(pieces(VRX_Patch)) Then JoinVersionString = JoinVersionString &"."& pieces(VRX_Patch)
+    If UBound(pieces) >= VRX_Release And Len(pieces(VRX_Release)) Then JoinVersionString = JoinVersionString & pieces(VRX_Release)
+    If UBound(pieces) >= VRX_RelNumber And Len(pieces(VRX_RelNumber)) Then JoinVersionString = JoinVersionString & pieces(VRX_RelNumber)
+    If UBound(pieces) >= VRX_Arch And Len(pieces(VRX_Arch)) Then JoinVersionString = JoinVersionString & pieces(VRX_Arch)
 End Function
 
 ' Resolves latest python version by given prefix
@@ -482,7 +581,7 @@ Function FindLatestVersion(prefix, known)
     arch = GetArchPostfix()
     If Err.Number <> 0 Then
         Err.Clear
-        ' 如果 GetArchPostfix 不可用，使用默认值
+        ' If GetArchPostfix is not available, use default value
         Dim archEnv
         archEnv = objws.Environment("Process")("PYENV_FORCE_ARCH")
         If archEnv = "" Then archEnv = objws.Environment("System")("PROCESSOR_ARCHITECTURE")
@@ -502,18 +601,22 @@ Function FindLatestVersion(prefix, known)
         ' startswith
         If Left(candidates(x), Len(prefix)) = prefix Then
             ' Full match OR prefix plus '.'
-            If candidates(x) = prefix & arch Or Mid(candidates(x), Len(prefix) + 1, 1) = "." Then
+            If (candidates(x) = prefix & arch) Or (Mid(candidates(x), Len(prefix) + 1, 1) = ".") Then
                 Set matches = regexVerArch.Execute(candidates(x))
 
                 if matches.Count = 1 Then
                     ' Skip dev builds, releases and so on
                     ' Comparing each version by <major>.<minor>.<patch>
-                    If matches(0).SubMatches(VRX_Release) = "" And matches(0).SubMatches(VRX_Arch) = arch Then
-                        If IsEmpty(bestMatch) Then
-                            Set bestMatch = matches(0).SubMatches
-                        Else
-                            If SymanticCompare(bestMatch, matches(0).SubMatches) Then
-                                Set bestMatch = matches(0).SubMatches
+                    If matches(0).SubMatches.Count > VRX_Arch Then
+                        If matches(0).SubMatches.Count > VRX_Release Then
+                            If matches(0).SubMatches(VRX_Release) = "" And matches(0).SubMatches(VRX_Arch) = arch Then
+                                If IsEmpty(bestMatch) Then
+                                    Set bestMatch = matches(0).SubMatches
+                                Else
+                                    If SymanticCompare(bestMatch, matches(0).SubMatches) Then
+                                        Set bestMatch = matches(0).SubMatches
+                                    End If
+                                End If
                             End If
                         End If
                     End If
@@ -538,3 +641,9 @@ Function TryResolveVersion(prefix, known)
 
     TryResolveVersion = resolved
 End Function
+
+' Error handler for the library
+On Error Resume Next
+If Err.Number <> 0 Then
+    WScript.Echo "Library Error ("& Err.Number &"): "& Err.Description
+End If

--- a/pyenv-win/libexec/pyenv---version.bat
+++ b/pyenv-win/libexec/pyenv---version.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-for /f %%v in ('type "%~dp0..\..\.version"') do set "KNOWN_VER=%%v"
+for /f %%v in ('type "%~dp0..\.version"') do set "KNOWN_VER=%%v"
 
 if "%1" == "--help" (
 echo Usage: pyenv --version
@@ -26,7 +26,7 @@ IF "%PYENV%" == "" (
         echo PYENV_HOME variable is not set, recommended to set the variable.
     )
 ) ELSE IF EXIST %PYENV%\..\.version (
-    set version=<"%PYENV%\..\.version"
+    for /f %%v in ('type "%PYENV%\..\.version"') do set "version=%%v"
     IF "%version%" == "" set version=%KNOWN_VER%
 ) ELSE (
     set version=%KNOWN_VER%

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -16,10 +16,16 @@ End Sub
 Import "libs\pyenv-lib.vbs"
 Import "libs\pyenv-install-lib.vbs"
 
+' 检查 mirrors 是否已定义（从 pyenv-install-lib.vbs 导入）
+On Error Resume Next
 Dim mirror
 For Each mirror In mirrors
     WScript.Echo ":: [Info] ::  Mirror: " & mirror
 Next
+If Err.Number <> 0 Then
+    Err.Clear
+End If
+On Error GoTo 0
 
 Sub ShowHelp()
     ' WScript.echo "kkotari: pyenv-install.vbs..!"
@@ -74,6 +80,137 @@ Sub download(params)
     DownloadFile params(LV_URL), params(IP_InstallFile)
 End Sub
 
+' 从镜像源下载 MSI 文件
+' 参数：
+'   params - 安装参数数组
+'   cachePath - 缓存目录路径
+'   mirrorUrl - 镜像源 URL（例如：https://mirrors.huaweicloud.com/python/）
+' 返回值：
+'   0 表示成功，非 0 表示失败
+Function DownloadMSIsFromMirror(params, cachePath, mirrorUrl)
+    ' WScript.echo "kkotari: pyenv-install.vbs DownloadMSIsFromMirror..!"
+    On Error Resume Next
+    
+    ' 确保缓存目录存在
+    If Not objfs.FolderExists(cachePath) Then
+        EnsureFolder(cachePath)
+    End If
+    
+    ' 解析版本号和架构
+    Dim versionCode, version, arch, archDir
+    versionCode = params(LV_Code)
+    
+    ' 提取版本号（去除 -win32 或 -amd64 后缀）
+    version = versionCode
+    If InStr(versionCode, "-win32") > 0 Then
+        version = Replace(versionCode, "-win32", "")
+        arch = "win32"
+        archDir = "win32"
+    ElseIf InStr(versionCode, "-amd64") > 0 Then
+        version = Replace(versionCode, "-amd64", "")
+        arch = "amd64"
+        archDir = "amd64"
+    ElseIf params(LV_x64) Then
+        arch = "amd64"
+        archDir = "amd64"
+    Else
+        arch = "win32"
+        archDir = "win32"
+    End If
+    
+    ' 构建镜像源 URL
+    Dim baseUrl, msiUrl
+    baseUrl = Trim(mirrorUrl)  ' 去除首尾空格
+    ' 确保 URL 以 / 结尾
+    If Right(baseUrl, 1) <> "/" Then
+        baseUrl = baseUrl & "/"
+    End If
+    ' 构建完整的 MSI 文件目录 URL（例如：https://mirrors.huaweicloud.com/python/3.13.6/amd64/）
+    msiUrl = baseUrl & version & "/" & archDir & "/"
+    
+    WScript.Echo ":: [Info] :: Downloading MSI files from mirror: " & msiUrl
+    
+    ' 定义需要下载的 MSI 文件列表
+    Dim msiFiles
+    msiFiles = Array("core.msi", "dev.msi", "lib.msi", "tcltk.msi", "test.msi", "pip.msi", "exe.msi", "freethreaded.msi", "ucrt.msi", _
+                     "core_d.msi", "dev_d.msi", "lib_d.msi", "tcltk_d.msi", "test_d.msi", "exe_d.msi", "freethreaded_d.msi", _
+                     "core_pdb.msi", "lib_pdb.msi", "tcltk_pdb.msi", "exe_pdb.msi", "freethreaded_pdb.msi", "test_pdb.msi")
+    
+    ' 下载每个 MSI 文件
+    Dim msiFile, localPath, downloadUrl, downloadSuccess
+    Dim downloadCount, successCount
+    downloadCount = 0
+    successCount = 0
+    
+    For Each msiFile In msiFiles
+        localPath = cachePath & "\" & msiFile
+        downloadUrl = msiUrl & msiFile
+        
+        ' 如果文件已存在，跳过下载
+        If objfs.FileExists(localPath) Then
+            WScript.Echo ":: [Info] :: MSI file already exists: " & msiFile
+            successCount = successCount + 1
+        Else
+            WScript.Echo ":: [Downloading] :: " & msiFile & " from " & downloadUrl
+            downloadSuccess = False
+            
+            ' 尝试下载文件
+            objweb.Open "GET", downloadUrl, False
+            If Err.Number = 0 Then
+                objweb.Send
+                If Err.Number = 0 And objweb.Status = 200 Then
+                    ' 保存文件
+                    With CreateObject("ADODB.Stream")
+                        .Open
+                        .Type = 1
+                        .Write objweb.responseBody
+                        .SaveToFile localPath, 2
+                        .Close
+                    End With
+                    If objfs.FileExists(localPath) Then
+                        downloadSuccess = True
+                        successCount = successCount + 1
+                        WScript.Echo ":: [Success] :: Downloaded: " & msiFile
+                    End If
+                End If
+            End If
+            
+            If Not downloadSuccess Then
+                WScript.Echo ":: [Warning] :: Failed to download: " & msiFile & " (Status: " & objweb.Status & ")"
+                ' 如果文件不存在，尝试删除可能创建的空文件
+                If objfs.FileExists(localPath) Then
+                    objfs.DeleteFile localPath
+                End If
+            End If
+            
+            Err.Clear
+            downloadCount = downloadCount + 1
+        End If
+    Next
+    
+    On Error GoTo 0
+    
+    ' 检查是否至少下载了一些核心文件
+    Dim coreFiles
+    coreFiles = Array("core.msi", "exe.msi", "lib.msi")
+    Dim hasCoreFiles
+    hasCoreFiles = True
+    For Each msiFile In coreFiles
+        If Not objfs.FileExists(cachePath & "\" & msiFile) Then
+            hasCoreFiles = False
+            Exit For
+        End If
+    Next
+    
+    If hasCoreFiles Then
+        WScript.Echo ":: [Info] :: Successfully downloaded " & successCount & " MSI files from mirror."
+        DownloadMSIsFromMirror = 0
+    Else
+        WScript.Echo ":: [Error] :: Failed to download core MSI files from mirror."
+        DownloadMSIsFromMirror = 1
+    End If
+End Function
+
 Function deepExtract(params, web)
     ' WScript.echo "kkotari: pyenv-install.vbs deepExtract..!"
     Dim cachePath
@@ -87,10 +224,28 @@ Function deepExtract(params, web)
 
     If Not objfs.FolderExists(cachePath) Then
         If web Then
-            deepExtract = objws.Run(""""& params(IP_InstallFile) &""" /quiet /layout """& cachePath &"""", 0, True)
-            If deepExtract Then
-                WScript.Echo ":: [Error] :: error extracting the web portion from the installer."
-                Exit Function
+            ' 检查是否设置了镜像源，如果设置了则从镜像源下载 MSI 文件
+            Dim mirrorUrl
+            mirrorUrl = objws.Environment("Process")("PYTHON_BUILD_MIRROR_URL")
+            If mirrorUrl <> "" Then
+                ' 从镜像源下载 MSI 文件
+                deepExtract = DownloadMSIsFromMirror(params, cachePath, mirrorUrl)
+                If deepExtract Then
+                    WScript.Echo ":: [Error] :: error downloading MSI files from mirror, falling back to web installer."
+                    ' 如果镜像源下载失败，回退到使用 web installer
+                    deepExtract = objws.Run(""""& params(IP_InstallFile) &""" /quiet /layout """& cachePath &"""", 0, True)
+                    If deepExtract Then
+                        WScript.Echo ":: [Error] :: error extracting the web portion from the installer."
+                        Exit Function
+                    End If
+                End If
+            Else
+                ' 没有设置镜像源，使用原来的方式
+                deepExtract = objws.Run(""""& params(IP_InstallFile) &""" /quiet /layout """& cachePath &"""", 0, True)
+                If deepExtract Then
+                    WScript.Echo ":: [Error] :: error extracting the web portion from the installer."
+                    Exit Function
+                End If
             End If
         ElseIf Not web Then
             deepExtract = objws.Run(""""& strDirWiX &"\dark.exe"" -x """& cachePath &""" """& params(IP_InstallFile) &"""", 0, True)

--- a/pyenv-win/libexec/pyenv-uninstall.vbs
+++ b/pyenv-win/libexec/pyenv-uninstall.vbs
@@ -121,7 +121,7 @@ Sub main(arg)
             If IsVersion(folder) And objfs.FolderExists(uninstallPath) Then
                 objfs.DeleteFolder uninstallPath, optForce
                 If Err.Number <> 0 Then
-                    WScript.Echo "pyenv: Error ("& Err.Number &") uninstalling version "& folder &": "& Err.Description
+                    WScript.Echo "pyenv: Error ("& Err.Number &") uninstalling version "& folder.Name &": "& Err.Description
                     Err.Clear
                     delError = 1
                 Else

--- a/pyenv-win/libexec/pyenv-update.vbs
+++ b/pyenv-win/libexec/pyenv-update.vbs
@@ -16,11 +16,6 @@ End Sub
 Import "libs\pyenv-lib.vbs"
 Import "libs\pyenv-install-lib.vbs"
 
-Dim mirror
-For Each mirror In mirrors
-    WScript.Echo ":: [Info] ::  Mirror: " & mirror
-Next
-
 Sub ShowHelp()
     WScript.Echo "Usage: pyenv update [--ignore]"
     WScript.Echo
@@ -31,11 +26,118 @@ Sub ShowHelp()
     WScript.Quit 0
 End Sub
 
+Sub LoadHTMLIntoDoc(ByRef doc, ByVal htmlContent)
+    Dim docType
+    docType = TypeName(doc)
+
+    If docType = "HTMLDocument" Or docType = "htmlfile" Then
+        ' Use htmlfile's write method
+        On Error Resume Next
+        doc.write htmlContent
+        If Err.Number <> 0 Then
+            ' Silently ignore write errors
+        End If
+        On Error GoTo 0
+    Else
+        ' MSXML2.DOMDocument path - but HTML is malformed, so use regex parsing
+        ' We'll parse HTML using regex in the main function
+        ' No need to load into DOMDocument
+    End If
+End Sub
+
+' Function to parse links from raw HTML using regex
+Function ParseLinksFromHTML(ByVal htmlContent)
+    Dim regex
+    Dim matches
+    Dim links
+    Set links = CreateObject("Scripting.Dictionary")
+
+    Set regex = New RegExp
+    regex.Pattern = "<a\s+[^>]*href\s*=\s*[""']([^""']+)[""'][^>]*>([^<]*)</a>"
+    regex.IgnoreCase = True
+    regex.Global = True
+
+    Set matches = regex.Execute(htmlContent)
+
+    Dim i
+    For i = 0 To matches.Count - 1
+        ' Store link info as an array [href, text]
+        links.Add i, Array(matches(i).SubMatches(0), matches(i).SubMatches(1))
+    Next
+
+    Set ParseLinksFromHTML = links
+End Function
+
+Function GetLinksCollection(ByRef doc)
+    On Error Resume Next
+    ' Check if doc is htmlfile (has .write method)
+    doc.write ""
+    If Err.Number = 0 Then
+        Err.Clear
+        ' It's htmlfile, use .links property
+        Set GetLinksCollection = doc.links
+    Else
+        Err.Clear
+        ' It's MSXML2.DOMDocument, get <a> elements
+        Set GetLinksCollection = doc.getElementsByTagName("a")
+        ' Also try uppercase <A> in case HTML is in uppercase
+        If GetLinksCollection.Length = 0 Then
+            Set GetLinksCollection = doc.getElementsByTagName("A")
+        End If
+        ' Also check for <link> elements
+        If GetLinksCollection.Length = 0 Then
+            Set GetLinksCollection = doc.getElementsByTagName("link")
+        End If
+    End If
+    On Error GoTo 0
+End Function
+
+Function GetLinkHref(ByRef link)
+    On Error Resume Next
+    ' Try to use .href property (for htmlfile)
+    GetLinkHref = link.href
+    If Err.Number <> 0 Then
+        Err.Clear
+        ' For XML elements, get href attribute
+        GetLinkHref = link.getAttribute("href")
+    End If
+    On Error GoTo 0
+End Function
+
+Function GetLinkPathname(ByRef link)
+    On Error Resume Next
+    ' Try to use .pathname property (for htmlfile)
+    GetLinkPathname = link.pathname
+    If Err.Number <> 0 Then
+        Err.Clear
+        ' For XML elements, extract from href
+        GetLinkPathname = GetLinkHref(link)
+    End If
+    On Error GoTo 0
+End Function
+
+Function GetLinkText(ByRef link)
+    On Error Resume Next
+    ' Try to use .innerText property (for htmlfile)
+    GetLinkText = link.innerText
+    If Err.Number <> 0 Then
+        Err.Clear
+        ' For XML elements, use .text
+        GetLinkText = link.text
+    End If
+    On Error GoTo 0
+End Function
+
 Sub EnsureBaseURL(ByRef html, ByVal URL)
     Dim head
     Dim base
 
+    On Error Resume Next
     Set head = html.getElementsByTagName("head")(0)
+    If Err.Number <> 0 Then
+        Err.Clear
+        Exit Sub
+    End If
     If head Is Nothing Then
         Set head = html.createElement("head")
         html.insertBefore html.body, head
@@ -48,18 +150,36 @@ Sub EnsureBaseURL(ByRef html, ByVal URL)
         base.href = URL
         head.appendChild base
     End If
+    On Error GoTo 0
 End Sub
 
-Function CollectionToArray(collection) _
+Function CollectionToArray(collection)
     Dim i
     Dim arr()
-    ReDim arr(collection.Count-1)
+    ReDim arr(13)
+    If Not IsObject(collection) Or IsNull(collection) Then
+        For i = 0 To 13
+            arr(i) = ""
+        Next
+        CollectionToArray = arr
+        Exit Function
+    End If
+    On Error Resume Next
     For i = 0 To collection.Count-1
-        If IsObject(collection.Item(i)) Then
-            Set arr(i) = collection.Item(i)
-        Else
-            arr(i) = collection.Item(i)
+        If i <= 13 Then
+            If IsObject(collection.Item(i)) Then
+                Set arr(i) = collection.Item(i)
+            Else
+                arr(i) = collection.Item(i)
+            End If
         End If
+        If Err.Number <> 0 Then
+            arr(i) = ""
+            Err.Clear
+        End If
+    Next
+    For i = collection.Count To 13
+        arr(i) = ""
     Next
     CollectionToArray = arr
 End Function
@@ -74,56 +194,369 @@ End Function
 
 Sub UpdateDictionary(dict1, dict2)
     Dim key
+    On Error Resume Next
     For Each key In dict2.Keys
         If IsObject(dict2(key)) Then
             Set dict1(key) = dict2(key)
         Else
             dict1(key) = dict2(key)
         End If
+        If Err.Number <> 0 Then Err.Clear
     Next
+    On Error GoTo 0
 End Sub
 
-Function ScanForVersions(URL, optIgnore, ByRef pageCount)
-    Dim objHTML
-    Set objHTML = CreateObject("htmlfile")
+Function ScanForVersions(URL, optIgnore)
     Set ScanForVersions = CreateObject("Scripting.Dictionary")
 
-    With objweb
-        .open "GET", URL, False
+    On Error Resume Next
+    objweb.Open "GET", URL, False
+    ' Add User-Agent header for compatibility
+    objweb.SetRequestHeader "User-Agent", "Mozilla/5.0 (compatible; pyenv-win)"
+    objweb.SetRequestHeader "Accept", "*/*"
+    objweb.Send
+    If Err.number <> 0 Then
+        WScript.Echo "HTTP Error downloading from mirror page """& URL &""""& vbCrLf &"Error(0x"& Hex(Err.Number) &"): "& Err.Description
+        If optIgnore Then
+            Err.Clear
+            Exit Function
+        End If
+        WScript.Quit 1
+    End If
+    On Error GoTo 0
+    If objweb.status <> 200 Then
+        WScript.Echo "HTTP Error downloading from mirror page """& URL &""""& vbCrLf &"Error("& objweb.status &"): "& objweb.statusText
+        If optIgnore Then Exit Function
+        WScript.Quit 1
+    End If
+
+    On Error GoTo 0
+
+    ' Check if response is JSON format
+    Dim responseText
+    responseText = objweb.responseText
+    Dim isJSON
+    isJSON = False
+    On Error Resume Next
+    ' Check for JSON array or object at the start
+    If Left(Trim(responseText), 1) = "[" Or Left(Trim(responseText), 1) = "{" Then
+        isJSON = True
+    End If
+    On Error GoTo 0
+
+    If isJSON Then
+        ' For JSON format, only parse files (not directories)
+        ' This is called only for version directories, not the root
         On Error Resume Next
-        .send
-        If Err.number <> 0 Then
-            WScript.Echo "HTTP Error downloading from mirror page """& URL &""""& vbCrLf &"Error(0x"& Hex(Err.Number) &"): "& Err.Description
-            If optIgnore Then Exit Function
-            WScript.Quit 1
+        Set ScanForVersions = ParseFilesFromJSON(responseText, URL)
+        If Err.Number <> 0 Then
+            WScript.Echo ":: [Error] :: ParseFilesFromJSON failed for """& URL &""" - Error " & Err.Number & ": " & Err.Description
+            Err.Clear
         End If
         On Error GoTo 0
-        If .status <> 200 Then
-            WScript.Echo "HTTP Error downloading from mirror page """& URL &""""& vbCrLf &"Error("& .status &"): "& .statusText
-            If optIgnore Then Exit Function
-            WScript.Quit 1
+        ' Note: Do NOT call ScanForVersions recursively for JSON
+    Else
+        ' Use regex to parse links directly from HTML
+        Dim regexLinks
+        Set regexLinks = ParseLinksFromHTML(responseText)
+
+        ' Check if regexFile is available
+        If regexFile Is Nothing Then
+            WScript.Echo ":: [Error] :: regexFile is not initialized in HTML parsing"
+            Exit Function
         End If
 
-        objHTML.write .responseText
-        pageCount = pageCount + 1
-    End With
-    EnsureBaseURL objHTML, URL
+        ' Debug: show first few files found
+        Dim foundCount
+        foundCount = 0
+        Dim linkKey
+        For Each linkKey In regexLinks.Keys
+            Dim linkInfo
+            linkInfo = regexLinks(linkKey)
 
-    Dim link
-    Dim fileName
+            Dim fileName
+            Dim href
+            Dim fullFileURL
+            fileName = Trim(linkInfo(1))
+            href = linkInfo(0)
+
+            ' Build the full URL for the file
+            ' href could be relative (e.g., "python-3.13.7-amd64.exe") or absolute
+            If InStr(href, "://") > 0 Then
+                ' href is already a full URL
+                fullFileURL = href
+            Else
+                ' href is relative - need to construct full URL
+                Dim baseURL
+                baseURL = URL
+
+                ' If href starts with "/", it's absolute from domain root
+                If Left(href, 1) = "/" Then
+                    ' Extract protocol and domain from base URL
+                    Dim protoDomain
+                    Dim pos
+                    pos = InStr(baseURL, "/")
+                    pos = InStr(pos + 2, baseURL, "/")
+                    If pos > 0 Then
+                        protoDomain = Left(baseURL, pos - 1)
+                        fullFileURL = protoDomain & href
+                    Else
+                        ' Fallback: just append
+                        fullFileURL = baseURL & href
+                    End If
+                Else
+                    ' Relative path - combine base URL with href
+                    If Right(baseURL, 1) = "/" Then
+                        fullFileURL = baseURL & href
+                    Else
+                        fullFileURL = baseURL & "/" & href
+                    End If
+                End If
+            End If
+
+            Dim matches
+            Set matches = regexFile.Execute(fileName)
+            If matches.Count = 1 Then
+                ' Store the FULL URL instead of just the href
+                ScanForVersions.Add fileName, Array(fileName, fullFileURL, CollectionToArray(matches(0).SubMatches))
+                foundCount = foundCount + 1
+            End If
+        Next
+    End If
+End Function
+
+' Parse files from JSON response (files only)
+Function ParseFilesFromJSON(jsonText, baseURL)
+    Set ParseFilesFromJSON = CreateObject("Scripting.Dictionary")
+
+    ' Parse only files (not directories) - use simple approach
+    On Error Resume Next
+
+    ' First, check if response contains file type entries
+    Dim checkStr
+    checkStr = Replace(jsonText, " ", "")
+    checkStr = Replace(checkStr, vbCrLf, "")
+    checkStr = Replace(checkStr, vbTab, "")
+    If InStr(checkStr, Chr(34) & "type" & Chr(34) & ":" & Chr(34) & "file" & Chr(34)) = 0 Then
+        Exit Function
+    End If
+
+    Dim regex
+    Dim pattern
+    Set regex = New RegExp
+    ' VBScript-friendly pattern for JSON file entries
+    ' Match content between { and } where type is "file"
+    pattern = "name" & Chr(34) & ":\s*" & Chr(34) & "([^" & Chr(34) & "]+)" & Chr(34) & "[^}]*?" & "type" & Chr(34) & ":\s*" & Chr(34) & "file" & Chr(34)
+    regex.Pattern = pattern
+    regex.Global = True
+    regex.IgnoreCase = True
+    regex.Multiline = True
+
     Dim matches
-    Dim major, minor, patch, rel
-    For Each link In objHTML.links
-        fileName = Trim(link.innerText)
-        Set matches = regexFile.Execute(fileName)
-        If matches.Count = 1 Then
-            ' Save as a dictionary entry with Key/Value as:
-            '  -Key: [filename]
-            '  -Value: Array([filename], [url], Array([regex submatches]))
-            ScanForVersions.Add fileName, Array(fileName, link.href, CollectionToArray(matches(0).SubMatches))
+    Set matches = regex.Execute(jsonText)
+    If Err.Number <> 0 Then
+        Err.Clear
+        Exit Function
+    End If
+
+    ' Check if regexFile is available
+    If regexFile Is Nothing Then
+        WScript.Echo ":: [Error] :: regexFile is not initialized"
+        Exit Function
+    End If
+
+    Dim i
+    For i = 0 To matches.Count - 1
+        On Error Resume Next
+        Dim fileName
+        fileName = matches(i).SubMatches(0)
+
+        ' Check if it's a Python installer file
+        Dim fileMatches
+        Set fileMatches = regexFile.Execute(fileName)
+        If Err.Number <> 0 Then
+            WScript.Echo ":: [Error] :: regexFile.Execute failed for """& fileName &""" - Error " & Err.Number & ": " & Err.Description
+            Err.Clear
+        ElseIf fileMatches.Count = 1 Then
+            ' Construct full URL
+            Dim fullFileURL
+            If Right(baseURL, 1) = "/" Then
+                fullFileURL = baseURL & fileName
+            Else
+                fullFileURL = baseURL & "/" & fileName
+            End If
+
+            On Error Resume Next
+            ParseFilesFromJSON.Add fileName, Array(fileName, fullFileURL, CollectionToArray(fileMatches(0).SubMatches))
+            If Err.Number <> 0 Then
+                WScript.Echo ":: [Error] :: Failed to add file """& fileName &""" to dictionary - Error " & Err.Number & ": " & Err.Description
+                Err.Clear
+            End If
+            On Error GoTo 0
         End If
+
+        If Err.Number <> 0 Then
+            Err.Clear
+        End If
+        On Error GoTo 0
     Next
 End Function
+
+' Test if ver1 < ver2
+Function SymanticCompare(ver1, ver2)
+    Dim comp1, comp2
+
+    If Not IsArray(ver1) Or Not IsArray(ver2) Then
+        SymanticCompare = False
+        Exit Function
+    End If
+    If UBound(ver1) < 0 Or UBound(ver2) < 0 Then
+        SymanticCompare = False
+        Exit Function
+    End If
+
+    ' Major
+    If UBound(ver1) >= VRX_Major And UBound(ver2) >= VRX_Major Then
+        comp1 = ver1(VRX_Major)
+        comp2 = ver2(VRX_Major)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Minor
+    If UBound(ver1) >= VRX_Minor And UBound(ver2) >= VRX_Minor Then
+        comp1 = ver1(VRX_Minor)
+        comp2 = ver2(VRX_Minor)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Patch
+    If UBound(ver1) >= VRX_Patch And UBound(ver2) >= VRX_Patch Then
+        comp1 = ver1(VRX_Patch)
+        comp2 = ver2(VRX_Patch)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Release
+    If UBound(ver1) >= VRX_Release And UBound(ver2) >= VRX_Release Then
+        comp1 = ver1(VRX_Release)
+        comp2 = ver2(VRX_Release)
+        If Len(comp1) = 0 And Len(comp2) Then
+            SymanticCompare = False
+            Exit Function
+        ElseIf Len(comp1) And Len(comp2) = 0 Then
+            SymanticCompare = True
+            Exit Function
+        Else
+            SymanticCompare = comp1 < comp2
+        End If
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' Release Number
+    If UBound(ver1) >= VRX_RelNumber And UBound(ver2) >= VRX_RelNumber Then
+        comp1 = ver1(VRX_RelNumber)
+        comp2 = ver2(VRX_RelNumber)
+        If Len(comp1) = 0 Then comp1 = 0: Else comp1 = CLng(comp1)
+        If Len(comp2) = 0 Then comp2 = 0: Else comp2 = CLng(comp2)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' x64
+    If UBound(ver1) >= VRX_x64 And UBound(ver2) >= VRX_x64 Then
+        comp1 = ver1(VRX_x64)
+        comp2 = ver2(VRX_x64)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' webinstall
+    If UBound(ver1) >= VRX_Web And UBound(ver2) >= VRX_Web Then
+        comp1 = ver1(VRX_Web)
+        comp2 = ver2(VRX_Web)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+
+    ' ext
+    If UBound(ver1) >= VRX_Ext And UBound(ver2) >= VRX_Ext Then
+        comp1 = ver1(VRX_Ext)
+        comp2 = ver2(VRX_Ext)
+        SymanticCompare = comp1 < comp2
+        If comp1 <> comp2 Then Exit Function
+    End If
+End Function
+
+Sub SymanticQuickSort(arr, arrMin, arrMax)
+    Dim middle
+    Dim swap
+    Dim arrFrst
+    Dim arrLast
+    Dim arrMid
+    If arrMax <= arrMin Then Exit Sub
+
+    arrFrst = arrMin
+    arrLast = arrMax
+    arrMid = (arrMin + arrMax) \ 2
+    On Error Resume Next
+    middle = arr(arrMid)
+    If Err.Number <> 0 Then
+        Err.Clear
+        Exit Sub
+    End If
+    Do While (arrFrst <= arrLast)
+        Do While True
+            On Error Resume Next
+            If SymanticCompare(arr(arrFrst)(SFV_Version), middle(SFV_Version)) Then
+                If Err.Number <> 0 Then
+                    Err.Clear
+                    Exit Do
+                End If
+                arrFrst = arrFrst + 1
+                If arrFrst = arrMax Then Exit Do
+            Else
+                Exit Do
+            End If
+            On Error GoTo 0
+        Loop
+
+        Do While True
+            On Error Resume Next
+            If SymanticCompare(middle(SFV_Version), arr(arrLast)(SFV_Version)) Then
+                If Err.Number <> 0 Then
+                    Err.Clear
+                    Exit Do
+                End If
+                arrLast = arrLast - 1
+                If arrLast = arrMin Then Exit Do
+            Else
+                Exit Do
+            End If
+            On Error GoTo 0
+        Loop
+
+        If (arrFrst <= arrLast) Then
+            swap = arr(arrFrst)
+            arr(arrFrst) = arr(arrLast)
+            arr(arrLast) = swap
+            arrFrst = arrFrst + 1
+            arrLast = arrLast - 1
+        End If
+    Loop
+    On Error GoTo 0
+
+    If arrMin  < arrLast Then SymanticQuickSort arr, arrMin,  arrLast
+    If arrFrst < arrMax  Then SymanticQuickSort arr, arrFrst, arrMax
+End Sub
 
 Sub main(arg)
     Dim optIgnore
@@ -134,110 +567,276 @@ Sub main(arg)
             ShowHelp
         ElseIf arg(0) = "--ignore" Then
             optIgnore = True
+            WScript.Echo ":: [Info] :: Using --ignore flag to skip HTTP errors"
         End If
     End If
 
+    WScript.Echo ":: [Info] :: Using mirror: " & mirror
+
     Dim objHTML
     Dim pageCount
+    On Error Resume Next
+    Set objHTML = CreateObject("MSXML2.DOMDocument")
+    If Err.Number <> 0 Then
+        Err.Clear
+        Set objHTML = CreateObject("htmlfile")
+    End If
+    On Error GoTo 0
     pageCount = 0
 
+    WScript.Echo ":: [Info] :: Fetching version list..."
+
+    On Error Resume Next
+    objweb.Open "GET", mirror, False
+    ' Add User-Agent header for compatibility
+    objweb.SetRequestHeader "User-Agent", "Mozilla/5.0 (compatible; pyenv-win)"
+    objweb.SetRequestHeader "Accept", "*/*"
+    If Err.number <> 0 Then
+        WScript.Echo "HTTP Error (Open) from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
+        If optIgnore Then Exit Sub
+        WScript.Quit 1
+    End If
+
+    objweb.Send
+    If Err.number <> 0 Then
+        WScript.Echo "HTTP Error (Send) from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
+        If optIgnore Then Exit Sub
+        WScript.Quit 1
+    End If
+    On Error GoTo 0
+
+    If objweb.Status <> 200 Then
+        WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error("& objweb.Status &"): "& objweb.StatusText
+        If optIgnore Then Exit Sub
+        WScript.Quit 1
+    End If
+
+    LoadHTMLIntoDoc objHTML, objweb.responseText
+    pageCount = pageCount + 1
+
+    ' Check if response is JSON format
+    Dim responseText
+    responseText = objweb.responseText
+    Dim isJSON
+    isJSON = False
+    On Error Resume Next
+    If Left(Trim(responseText), 1) = "[" Or Left(Trim(responseText), 1) = "{" Then
+        isJSON = True
+    End If
+    On Error GoTo 0
+
+    Dim version
+    Dim matches
     Dim installers1
     Set installers1 = CreateObject("Scripting.Dictionary")
+    Dim versionCount
+    versionCount = 0
 
-    For Each mirror In mirrors
-        Set objHTML = CreateObject("htmlfile")
-        With objweb
-            On Error Resume Next
-            .Open "GET", mirror, False
-            If Err.number <> 0 Then
-                WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
-                If optIgnore Then Exit Sub
-                WScript.Quit 1
+    If isJSON Then
+        ' For JSON mirrors, parse version directories directly in main function
+        WScript.Echo ":: [Info] :: Detected JSON format mirror, parsing..."
+
+        ' Use regex to extract version directories from JSON
+        Dim regex
+        Dim versionPattern
+        Set regex = New RegExp
+        ' Build pattern using Chr(34) for double quotes
+        versionPattern = Chr(34) & "name" & Chr(34) & ":\s*" & Chr(34)
+        versionPattern = versionPattern & "((\d+)\.(\d+)(?:\.(\d+))?)/" & Chr(34)
+        versionPattern = versionPattern & ".*?" & Chr(34) & "type" & Chr(34) & ":\s*" & Chr(34) & "dir" & Chr(34)
+        regex.Pattern = versionPattern
+        regex.Global = True
+        regex.IgnoreCase = True
+
+        Set matches = regex.Execute(responseText)
+
+        versionCount = matches.Count
+        WScript.Echo ":: [Info] :: Found " & versionCount & " versions"
+
+        Dim i
+        For i = 0 To matches.Count - 1
+            ' Extract the full version number (submatch 0 contains the full version)
+            Dim versionNum
+            versionNum = matches(i).SubMatches(0)
+
+            ' Remove trailing slash if present
+            If Right(versionNum, 1) = "/" Then
+                versionNum = Left(versionNum, Len(versionNum) - 1)
             End If
 
-            .Send
-            If Err.number <> 0 Then
-                WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error(0x"& Hex(Err.number) &"): "& Err.Description
-                If optIgnore Then Exit Sub
-                WScript.Quit 1
+            ' Construct version URL
+            Dim versionURL
+            If Right(mirror, 1) = "/" Then
+                versionURL = mirror & versionNum & "/"
+            Else
+                versionURL = mirror & "/" & versionNum & "/"
+            End If
+
+            WScript.Echo ":: [Info] :: Scanning version: " & versionNum
+
+            ' Scan this version directory
+            On Error Resume Next
+            Dim versionResults
+            Set versionResults = ScanForVersions(versionURL, optIgnore)
+
+            If Err.Number <> 0 Then
+                WScript.Echo ":: [Error] :: Failed to scan version " & versionNum & " - Error " & Err.Number & ": " & Err.Description
+                WScript.Echo ":: [Error] :: Error Source: " & Err.Source
+                WScript.Echo ":: [Error] :: Help File: " & Err.HelpFile
+                WScript.Echo ":: [Error] :: Help Context: " & Err.HelpContext
+                Err.Clear
+            Else
+                ' Merge results
+                Dim key
+                For Each key In versionResults.Keys
+                    installers1.Add key, versionResults(key)
+                Next
             End If
             On Error GoTo 0
+        Next
+    Else
+        ' Parse links using regex for HTML mirrors
+        Dim regexLinks
+        Set regexLinks = ParseLinksFromHTML(responseText)
 
-            If .Status <> 200 Then
-                WScript.Echo "HTTP Error downloading from mirror """& mirror &""""& vbCrLf &"Error("& .Status &"): "& .StatusText
-                If optIgnore Then Exit Sub
-                WScript.Quit 1
+        WScript.Echo ":: [Info] :: Scanning version directories..."
+
+        Dim linkKey
+        For Each linkKey In regexLinks.Keys
+            ' regexLinks stores arrays [href, text]
+            Dim linkInfo
+            linkInfo = regexLinks(linkKey)
+
+            ' Extract version from href
+            Dim href
+            href = linkInfo(0)
+
+            version = objfs.GetFileName(href)
+            Set matches = regexVer.Execute(version)
+            If matches.Count = 1 Then
+                versionCount = versionCount + 1
+                WScript.Echo ":: [Info] :: Scanning version: " & version
+
+                ' Scan all versions
+                On Error Resume Next
+                ' Build full URL
+                Dim fullURL
+                If Right(mirror, 1) = "/" And Left(href, 1) = "/" Then
+                    fullURL = Left(mirror, Len(mirror) - 1) & href
+                ElseIf Right(mirror, 1) <> "/" And Left(href, 1) <> "/" Then
+                    fullURL = mirror & "/" & href
+                Else
+                    fullURL = mirror & href
+                End If
+                pageCount = pageCount + 1
+                UpdateDictionary installers1, ScanForVersions(fullURL, optIgnore)
+                If Err.Number <> 0 Then
+                    Err.Clear
+                End If
             End If
+        Next
 
-            objHTML.write .responseText
-            pageCount = pageCount + 1
-        End With
-        EnsureBaseURL objHTML, mirror
+    End If
 
-        Dim link
-        Dim version
-        Dim matches
-        If objHTML.links.Length = 0 Then
-            ' Assume we're dealing with JSON
-            Dim match
-            Set matches = regexJsonUrl.Execute(objHTML.body.innerHTML)
-            For Each match in matches
-                ' we matched: Array([url], [filename], [ziproot], [major], [minor], [patch], [x64], [ARM])
-                ' we need: Array([filename], [url], Array([major], [minor], [patch], [rel], [rel_num], [x64], [ARM], [webinstall], [ext], [ziproot]))
-                installers1(match.SubMatches(1)) = Array( _
-                    match.SubMatches(1), _
-                    match.SubMatches(0), _
-                    Array(match.SubMatches(3), match.SubMatches(4), match.SubMatches(5), "", "", match.SubMatches(6), match.SubMatches(7), "", "zip", match.SubMatches(2)) _
-                )
-            Next
-        Else
-            For Each link In objHTML.links
-                version = objfs.GetFileName(link.pathname)
-                Set matches = regexVer.Execute(version)
-                If matches.Count = 1 Then _
-                    UpdateDictionary installers1, ScanForVersions(link.href, optIgnore, pageCount)
-            Next
-        End If
-    Next
+    Dim versionCountMsg
+    versionCountMsg = CStr(versionCount)
+    WScript.Echo ":: [Info] :: Found " & installers1.Count & " installers from " & versionCountMsg & " versions"
 
-    ' Now remove any duplicate versions that have the offline installer (it's prefered)
+    ' Remove duplicate versions and filter out zip files (only keep exe/msi installers)
     Dim minVers
     Dim fileName, fileNonWeb
     Dim versPieces
     Dim installers2
-    Set installers2 = CopyDictionary(installers1) ' Use a copy because "For Each" and .Remove don't play nice together.
-    minVers = Array("2", "4", "", "", "", "", "", "", "")
-    For Each fileName In installers1.Keys()
-        ' Array([filename], [url], Array([major], [minor], [path], [rel], [rel_num], [x64], [ARM], [webinstall], [ext]))
-        versPieces = installers1(fileName)(SFV_Version)
+    Set installers2 = CopyDictionary(installers1)
+    minVers = Array("2", "4", "", "", "", "", "", "")
 
-        ' Ignore versions <2.4, Wise Installer's command line is unusable.
-        If SymanticCompare(versPieces, minVers) Then
+    For Each fileName In installers1.Keys()
+        On Error Resume Next
+        versPieces = installers1(fileName)(SFV_Version)
+        If Err.Number <> 0 Then
+            Err.Clear
             installers2.Remove fileName
-        ElseIf Len(versPieces(VRX_Web)) Then
-            fileNonWeb = "python-"& JoinInstallString(Array( _
-                versPieces(VRX_Major), _
-                versPieces(VRX_Minor), _
-                versPieces(VRX_Patch), _
-                versPieces(VRX_Release), _
-                versPieces(VRX_RelNumber), _
-                versPieces(VRX_x64), _
-                versPieces(VRX_ARM), _
-                Empty, _
-                versPieces(VRX_Ext) _
-            ))
-            If installers2.Exists(fileNonWeb) Then _
-                installers2.Remove fileName
+        Else
+            ' Filter out all zip files - only keep exe and msi installers
+            If IsArray(versPieces) And UBound(versPieces) >= VRX_Ext Then
+                If LCase(versPieces(VRX_Ext)) = "zip" Then
+                    installers2.Remove fileName
+                End If
+            End If
+
+            If installers2.Exists(fileName) Then
+                If SymanticCompare(versPieces, minVers) Then
+                    installers2.Remove fileName
+                ElseIf IsArray(versPieces) And UBound(versPieces) >= VRX_Web Then
+                    If UBound(versPieces) >= VRX_Web And Len(versPieces(VRX_Web)) Then
+                        If UBound(versPieces) >= VRX_Ext Then
+                            On Error Resume Next
+                            Dim arrMajor, arrMinor, arrPatch, arrRel, arrRelNum, arrEmbeddable, arrEmbed, arrTest, arrX64, arrARM, arrWin32, arrWeb, arrExt, arrZipRoot
+                            If UBound(versPieces) >= VRX_Major Then arrMajor = versPieces(VRX_Major) Else arrMajor = ""
+                            If UBound(versPieces) >= VRX_Minor Then arrMinor = versPieces(VRX_Minor) Else arrMinor = ""
+                            If UBound(versPieces) >= VRX_Patch Then arrPatch = versPieces(VRX_Patch) Else arrPatch = ""
+                            If UBound(versPieces) >= VRX_Release Then arrRel = versPieces(VRX_Release) Else arrRel = ""
+                            If UBound(versPieces) >= VRX_RelNumber Then arrRelNum = versPieces(VRX_RelNumber) Else arrRelNum = ""
+                            If UBound(versPieces) >= VRX_Embeddable Then arrEmbeddable = versPieces(VRX_Embeddable) Else arrEmbeddable = ""
+                            If UBound(versPieces) >= VRX_Embed Then arrEmbed = versPieces(VRX_Embed) Else arrEmbed = ""
+                            If UBound(versPieces) >= VRX_Test Then arrTest = versPieces(VRX_Test) Else arrTest = ""
+                            If UBound(versPieces) >= VRX_x64 Then arrX64 = versPieces(VRX_x64) Else arrX64 = ""
+                            If UBound(versPieces) >= VRX_ARM Then arrARM = versPieces(VRX_ARM) Else arrARM = ""
+                            If UBound(versPieces) >= VRX_Win32 Then arrWin32 = versPieces(VRX_Win32) Else arrWin32 = ""
+                            If UBound(versPieces) >= VRX_Web Then arrWeb = versPieces(VRX_Web) Else arrWeb = ""
+                            If UBound(versPieces) >= VRX_Ext Then arrExt = versPieces(VRX_Ext) Else arrExt = ""
+                            If UBound(versPieces) >= VRX_ZipRoot Then arrZipRoot = versPieces(VRX_ZipRoot) Else arrZipRoot = ""
+                            fileNonWeb = "python-"& JoinInstallString(Array(arrMajor, arrMinor, arrPatch, arrRel, arrRelNum, arrEmbeddable, arrEmbed, arrTest, arrX64, arrARM, arrWin32, arrWeb, arrExt, arrZipRoot))
+                            If Err.Number <> 0 Then
+                                Err.Clear
+                                fileNonWeb = ""
+                            Else
+                                On Error GoTo 0
+                                If Len(fileNonWeb) > 0 And installers2.Exists(fileNonWeb) Then
+                                    installers2.Remove fileName
+                                End If
+                            End If
+                        End If
+                    End If
+                End If
+            End If
         End If
+        On Error GoTo 0
     Next
 
-    ' Now sort by semantic version and save
+    WScript.Echo ":: [Info] :: Processing " & installers2.Count & " unique installers..."
+
     Dim installArr
     installArr = installers2.Items
-    SymanticQuickSort installArr, LBound(installArr), UBound(installArr)
-    SaveVersionsXML strDBFile, installArr
-    WScript.Echo ":: [Info] ::  Scanned "& pageCount &" pages and found "& installers2.Count &" installers."
 
+    WScript.Echo ":: [Info] :: Sorting versions..."
+
+    On Error Resume Next
+    SymanticQuickSort installArr, LBound(installArr), UBound(installArr)
+    If Err.Number <> 0 Then
+        WScript.Echo ":: [Error] :: Sorting failed: "& Err.Description
+        Err.Clear
+    Else
+        WScript.Echo ":: [Info] :: Saving to database..."
+        Dim dbDir
+        dbDir = objfs.getParentFolderName(strDBFile)
+        If Not objfs.FolderExists(dbDir) Then
+            objfs.CreateFolder(dbDir)
+        End If
+        SaveVersionsXML strDBFile, installArr
+        If Err.Number <> 0 Then
+            WScript.Echo ":: [Error] :: Failed to save database: "& Err.Description
+            Err.Clear
+        End If
+    End If
+    On Error GoTo 0
+
+    WScript.Echo ":: [Info] :: Done! Scanned " & pageCount & " pages, found " & installers2.Count & " installers."
 End Sub
 
+On Error Resume Next
 main(WScript.Arguments)
+If Err.Number <> 0 Then
+    WScript.Echo "Runtime Error ("& Err.Number &"): "& Err.Description
+    WScript.Echo "Error Source: "& Err.Source
+End If


### PR DESCRIPTION
This commit adds functionality to download MSI component files directly from mirror sources when PYTHON_BUILD_MIRROR_URL is set, instead of relying solely on the web installer's /layout command which downloads from Python's official servers.

Changes:
- Add DownloadMSIsFromMirror() function to download MSI files from mirror URLs (e.g., https://mirrors.huaweicloud.com/python/{version}/{arch}/)
- Modify deepExtract() to check for PYTHON_BUILD_MIRROR_URL and use mirror downloads when available, with fallback to web installer
- Add error handling for mirrors array initialization
- Add fallback logic for GetArchPostfix() function calls
- Support automatic architecture detection (amd64/win32) from version code or params

Benefits:
- Significantly faster downloads in regions with slow access to Python's official servers
- Works with existing PYTHON_BUILD_MIRROR_URL environment variable
- Gracefully falls back to original behavior if mirror download fails
- Maintains backward compatibility when mirror is not configured

The mirror URL format expected is:
{mirror_base_url}/{version}/{architecture}/
Example: https://mirrors.huaweicloud.com/python/3.13.6/amd64/