### PR TITLE
docs: update MIT license link to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Please see the [Changelog](./docs/changelog.md) page.
 
 ## License and Copyright
 
-- pyenv-win is licensed under [MIT](http://opensource.org/licenses/mit-license.php) _2019_
+- pyenv-win is licensed under [MIT](https://opensource.org/licenses/mit-license.php) _2019_
 
    [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary
Update MIT license link from HTTP to HTTPS.

## Changes
- Line 233: Replace `http://opensource.org/licenses/mit-license.php` with HTTPS

## Verification
- HTTPS URL confirmed working
- HTTP redirects to HTTPS (301)

## Type
- [x] Documentation

Improves security by using HTTPS for license link.