### PR TITLE
Support GraalPy assets with Python version prefix.

### DIFF
--- a/.github/scripts/update_versions_cache.py
+++ b/.github/scripts/update_versions_cache.py
@@ -29,7 +29,7 @@ REGEX_FILE = re.compile(
 )
 
 REGEX_JSON_URL = re.compile(
-    r'"download_url":\s*"(https://[^\s"]+/((?:pypy\d+\.\d+-v|graalpy-)(\d+)(?:\.(\d+))?(?:\.(\d+))?-(?:(win64|windows-amd64)|(windows-aarch64))\.zip))"'
+    r'"download_url":\s*"(https://[^\s"]+/((?:pypy\d+\.\d+-v|graalpy(?:\d+\.\d+)?-)(\d+)(?:\.(\d+))?(?:\.(\d+))?-(?:(win64|windows-amd64)|(windows-aarch64))\.zip))"'
 )
 
 REGEX_VER = re.compile(r'^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?$', re.IGNORECASE)
@@ -178,7 +178,7 @@ def scan_json_releases(mirror_url):
                         continue
                     
                     # Match: graalpy-23.1.0-windows-amd64.zip
-                    match = re.match(r'^(graalpy-(\d+)\.(\d+)\.(\d+)-(windows-amd64|windows-aarch64))\.zip$', name)
+                    match = re.match(r'^(graalpy(?:\d+\.\d+)?-(\d+)\.(\d+)\.(\d+)-(windows-amd64|windows-aarch64))\.zip$', name)
                     if match:
                         zip_root = match.group(1)
                         download_url = asset.get('browser_download_url', '')
@@ -310,7 +310,7 @@ def sort_versions(installers):
             return (impl_type, major, minor, patch, rel_sort[0], rel_sort[1], rel_sort[2], arch_sort, code)
         
         # For pypy/graalpy, extract version numbers
-        numbers = re.findall(r'\d+', code)
+        numbers = re.findall(r'\d+', re.sub(r'^graalpy\d+\.\d+-', 'graalpy-', code))
         return (impl_type,) + tuple(int(n) for n in numbers) + (0, '', 0, 0, code,)
     
     return sorted(installers.items(), key=version_key)

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -71,7 +71,7 @@ End With
 With regexJsonUrl
     ' example for graalpy: graalpy-24.0.1-windows-amd64.zip
     ' example for pypy: pypy3.7-v7.3.4-win64.zip
-    .Pattern = "download_url"": ?""(https://[^\s""]+/(((?:pypy\d+\.\d+-v|graalpy-)(\d+)(?:\.(\d+))?(?:\.(\d+))?-(win64|windows-amd64)?(windows-aarch64)?).zip))"""
+    .Pattern = "download_url"": ?""(https://[^\s""]+/(((?:pypy\d+\.\d+-v|graalpy(?:\d+\.\d+)?-)(\d+)(?:\.(\d+))?(?:\.(\d+))?-(win64|windows-amd64)?(windows-aarch64)?).zip))"""
     .Global = True
     .IgnoreCase = True
 End With


### PR DESCRIPTION
With https://github.com/oracle/graalpython/pull/810 we will slightly alter upcoming GraalPy release artifact naming. The name will now include the compatible CPython version name in the filename. This change adapts version caching and downloads scripts to support both the older and newer format.

/cc @msimacek
Related:  https://github.com/oracle/graalpython/issues/623