### PR TITLE
Add Windows ARM64 support

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,4 +1,5 @@
-export HOME="/d/a/pyenv-win/pyenv-win"
+# The workspace drive differs per runner image (D: on windows-latest, C: on windows-11-arm).
+export HOME="$PWD"
 export PYENV="$HOME/pyenv-win"
 export PYENV_HOME="$HOME/pyenv-win"
 export PYENV_ROOT="$HOME/pyenv-win"

--- a/.github/scripts/ps1.sh
+++ b/.github/scripts/ps1.sh
@@ -1,4 +1,4 @@
-export HOME="/c/Users/runneradmin/.pyenv"
+export HOME="$(cygpath -u "$USERPROFILE")/.pyenv"
 export PYENV="$HOME/pyenv-win"
 export PYENV_HOME="$HOME/pyenv-win"
 export PYENV_ROOT="$HOME/pyenv-win"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,15 +12,34 @@ on:
 
 jobs:
   build:
-    name: pyenv-win pytest
-    runs-on: windows-latest
-    env:
-      HOME: D:/a/pyenv-win/pyenv-win
+    name: pyenv-win pytest (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-11-arm]
     steps:
 
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: report architecture and script engine
+        shell: pwsh
+        run: |
+          "Runner label          : ${{ matrix.os }}"
+          "PROCESSOR_ARCHITECTURE: $env:PROCESSOR_ARCHITECTURE"
+          "Machine architecture  : $([Environment]::GetEnvironmentVariable('PROCESSOR_ARCHITECTURE','Machine'))"
+          "OS                    : $((Get-CimInstance Win32_OperatingSystem).Caption)"
+
+          # VBScript is a Feature on Demand; pyenv-win cannot run without it.
+          $probe = Join-Path $env:RUNNER_TEMP 'probe.vbs'
+          Set-Content -Path $probe -Value 'WScript.Quit 0' -Encoding ASCII
+          & cscript.exe //nologo //B $probe
+          if ($LASTEXITCODE -ne 0) {
+            throw "VBScript engine unavailable on this image (cscript exit $LASTEXITCODE)."
+          }
+          'VBScript engine: OK'
+
       - name: pytest bash script
-        run: ${{ env.HOME }}/.github/scripts/build.sh
+        run: bash ./.github/scripts/build.sh
         shell: bash

--- a/.github/workflows/pytest_ps1.yml
+++ b/.github/workflows/pytest_ps1.yml
@@ -12,10 +12,12 @@ on:
 
 jobs:
   build:
-    name: pyenv-win pytest_ps1
-    runs-on: windows-latest
-    env:
-      HOME: D:/a/pyenv-win/pyenv-win
+    name: pyenv-win pytest_ps1 (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-11-arm]
     steps:
 
       - name: checkout
@@ -23,10 +25,13 @@ jobs:
 
       - name: pytest_ps1 pwsh command
         shell: pwsh
-        run : |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
+        env:
+          SRC_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          SRC_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          Write-Host "Installing from $env:SRC_REPO @ $env:SRC_REF"
+          ./pyenv-win/install-pyenv-win.ps1 -Repo $env:SRC_REPO -Ref $env:SRC_REF
 
       - name: pytest bash script
-        run: ${{ env.HOME }}/.github/scripts/ps1.sh
+        run: bash ./.github/scripts/ps1.sh
         shell: bash

--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -131,11 +131,12 @@ Function Main() {
         "-Command `"Microsoft.PowerShell.Archive\Expand-Archive -Path \`"$DownloadPath\`" -DestinationPath \`"$PyEnvDir\`"`""
     ) -NoNewWindow -Wait
 
-    # GitHub names the extracted folder after the ref, with slashes replaced by dashes.
+    # GitHub names the extracted folder "<repo>-<ref>", with slashes replaced by dashes.
+    $RepoName = $Repo.Split("/")[-1]
     $ExtractedDir = Get-ChildItem -Path $PyEnvDir -Directory |
-        Where-Object { $_.Name -like "pyenv-win-*" } | Select-Object -First 1
+        Where-Object { $_.Name -like "${RepoName}-*" } | Select-Object -First 1
     If (-not $ExtractedDir) {
-        Write-Host "Could not find the extracted archive in $PyEnvDir."
+        Write-Host "Could not find an extracted '${RepoName}-*' folder in $PyEnvDir."
         exit 1
     }
     Move-Item -Path "$($ExtractedDir.FullName)\*" -Destination "$PyEnvDir"

--- a/pyenv-win/install-pyenv-win.ps1
+++ b/pyenv-win/install-pyenv-win.ps1
@@ -9,6 +9,12 @@
     .PARAMETER Uninstall
     Uninstall pyenv-win. Note that this uninstalls any Python versions that were installed with pyenv-win.
 
+    .PARAMETER Repo
+    GitHub repository to install from. Defaults to the official one.
+
+    .PARAMETER Ref
+    Branch, tag or commit SHA to install. Defaults to master.
+
     .INPUTS
     None.
 
@@ -21,16 +27,18 @@
     .LINK
     Online version: https://pyenv-win.github.io/pyenv-win/
 #>
-    
+
 param (
-    [Switch] $Uninstall = $False
+    [Switch] $Uninstall = $False,
+    [String] $Repo = "pyenv-win/pyenv-win",
+    [String] $Ref = "master"
 )
-    
+
 $PyEnvDir = "${env:USERPROFILE}\.pyenv"
 $PyEnvWinDir = "${PyEnvDir}\pyenv-win"
 $BinPath = "${PyEnvWinDir}\bin"
 $ShimsPath = "${PyEnvWinDir}\shims"
-    
+
 Function Remove-PyEnvVars() {
     $PathParts = [System.Environment]::GetEnvironmentVariable('PATH', "User") -Split ";"
     $NewPathParts = $PathParts.Where{ $_ -ne $BinPath }.Where{ $_ -ne $ShimsPath }
@@ -65,7 +73,7 @@ Function Get-CurrentVersion() {
 
 Function Get-LatestVersion() {
     $LatestVersionFilePath = "$PyEnvDir\latest.version"
-    (New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/.version", $LatestVersionFilePath)
+    (New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/${Repo}/${Ref}/.version", $LatestVersionFilePath)
     $LatestVersion = Get-Content $LatestVersionFilePath
 
     Remove-Item -Path $LatestVersionFilePath
@@ -86,7 +94,7 @@ Function Main() {
     }
 
     $BackupDir = "${env:Temp}/pyenv-win-backup"
-    
+
     $CurrentVersion = Get-CurrentVersion
     If ($CurrentVersion) {
         Write-Host "pyenv-win $CurrentVersion installed."
@@ -97,7 +105,7 @@ Function Main() {
         }
         Else {
             Write-Host "New version available: $LatestVersion. Updating..."
-            
+
             Write-Host "Backing up existing Python installations..."
             $FoldersToBackup = "install_cache", "versions", "shims"
             ForEach ($Dir in $FoldersToBackup) {
@@ -106,25 +114,32 @@ Function Main() {
                 }
                 Move-Item -Path "${PyEnvWinDir}/${Dir}" -Destination $BackupDir
             }
-            
+
             Write-Host "Removing $PyEnvDir..."
             Remove-Item -Path $PyEnvDir -Recurse
-        }   
+        }
     }
 
     New-Item -Path $PyEnvDir -ItemType Directory
 
     $DownloadPath = "$PyEnvDir\pyenv-win.zip"
 
-    (New-Object System.Net.WebClient).DownloadFile("https://github.com/pyenv-win/pyenv-win/archive/master.zip", $DownloadPath)
+    (New-Object System.Net.WebClient).DownloadFile("https://github.com/${Repo}/archive/${Ref}.zip", $DownloadPath)
 
     Start-Process -FilePath "powershell.exe" -ArgumentList @(
         "-NoProfile",
         "-Command `"Microsoft.PowerShell.Archive\Expand-Archive -Path \`"$DownloadPath\`" -DestinationPath \`"$PyEnvDir\`"`""
     ) -NoNewWindow -Wait
 
-    Move-Item -Path "$PyEnvDir\pyenv-win-master\*" -Destination "$PyEnvDir"
-    Remove-Item -Path "$PyEnvDir\pyenv-win-master" -Recurse
+    # GitHub names the extracted folder after the ref, with slashes replaced by dashes.
+    $ExtractedDir = Get-ChildItem -Path $PyEnvDir -Directory |
+        Where-Object { $_.Name -like "pyenv-win-*" } | Select-Object -First 1
+    If (-not $ExtractedDir) {
+        Write-Host "Could not find the extracted archive in $PyEnvDir."
+        exit 1
+    }
+    Move-Item -Path "$($ExtractedDir.FullName)\*" -Destination "$PyEnvDir"
+    Remove-Item -Path $ExtractedDir.FullName -Recurse
     Remove-Item -Path $DownloadPath
 
     # Update env vars
@@ -144,7 +159,7 @@ Function Main() {
         Write-Host "Restoring Python installations..."
         Move-Item -Path "$BackupDir/*" -Destination $PyEnvWinDir
     }
-    
+
     If ($? -eq $True) {
         Write-Host "pyenv-win is successfully installed. You may need to close and reopen your terminal before using it."
     }

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -37,13 +37,13 @@ Const LV_x64 = 3
 Const LV_Web = 4
 Const LV_MSI = 5
 Const LV_ZipRootDir = 6
-' Const LV_ARM = 7 # need to validate what number is this
+Const LV_ARM = 7
 
 ' Installation parameters used for clear/extract, extension of LV.
-Const IP_InstallPath = 7
-Const IP_InstallFile = 8
-Const IP_Quiet = 9
-Const IP_Dev = 10
+Const IP_InstallPath = 8
+Const IP_InstallFile = 9
+Const IP_Quiet = 10
+Const IP_Dev = 11
 
 Dim regexVer
 Dim regexVerArch
@@ -59,7 +59,8 @@ With regexVer
     .IgnoreCase = True
 End With
 With regexVerArch
-    .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?([\.-](?:amd64|arm64|win32))?$"
+    ' "-arm" is the canonical postfix emitted by JoinWin32String; the others are accepted as user input.
+    .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?([\.-](?:amd64|arm64|arm|win32))?$"
     .Global = True
     .IgnoreCase = True
 End With
@@ -227,7 +228,8 @@ Function LoadVersionsXML(xmlPath)
             CBool(version.getAttribute("x64")), _
             CBool(version.getAttribute("webInstall")), _
             CBool(version.getAttribute("msi")), _
-            zipRootDir _
+            zipRootDir, _
+            (Right(LCase(code), 4) = "-arm") _
         )
     Next
 End Function
@@ -441,38 +443,11 @@ Function JoinVersionString(pieces)
     If Len(pieces(VRX_Arch))      Then JoinVersionString = JoinVersionString & pieces(VRX_Arch)
 End Function
 
-' Resolves latest python version by given prefix
-' known=False to find latest _installed_ version
-' See `pyenv latest --help`
-Function FindLatestVersion(prefix, known)
-    Dim candidates
-
-    if known Then
-        Dim cachedVersions
-        Set cachedVersions = LoadVersionsXML(strDBFile)
-
-        Dim cachedVersion
-
-        Dim convertor()
-        ReDim Preserve convertor(-1)
-
-        For Each cachedVersion In cachedVersions.Keys
-            ReDim Preserve convertor(UBound(convertor) + 1)
-            convertor(UBound(convertor)) = cachedVersion
-        Next
-
-        candidates = convertor
-    else
-        candidates = GetInstalledVersions()
-    end if
-
+' Finds the newest candidate matching prefix for exactly one architecture postfix.
+Function FindLatestForArch(candidates, prefix, arch)
     Dim x
     Dim matches
-
     Dim bestMatch
-    Dim arch
-
-    arch = GetArchPostfix()
 
     For x = 0 To UBound(candidates) Step 1
         ' startswith
@@ -498,11 +473,57 @@ Function FindLatestVersion(prefix, known)
         End If
     Next
 
-    if IsEmpty(bestMatch) Then
-        FindLatestVersion = ""
+    If IsEmpty(bestMatch) Then
+        FindLatestForArch = ""
+    Else
+        FindLatestForArch = JoinVersionString(bestMatch)
+    End If
+End Function
+
+' Resolves latest python version by given prefix
+' known=False to find latest _installed_ version
+' See `pyenv latest --help`
+Function FindLatestVersion(prefix, known)
+    Dim candidates
+
+    if known Then
+        Dim cachedVersions
+        Set cachedVersions = LoadVersionsXML(strDBFile)
+
+        Dim cachedVersion
+
+        Dim convertor()
+        ReDim Preserve convertor(-1)
+
+        For Each cachedVersion In cachedVersions.Keys
+            ReDim Preserve convertor(UBound(convertor) + 1)
+            convertor(UBound(convertor)) = cachedVersion
+        Next
+
+        candidates = convertor
     else
-        FindLatestVersion = JoinVersionString(bestMatch)
+        candidates = GetInstalledVersions()
     end if
+
+    FindLatestVersion = FindLatestForArch(candidates, prefix, GetArchPostfix())
+
+    ' Not every release ships a native ARM64 build; the x64 build runs under emulation.
+    If FindLatestVersion = "" And IsArm() Then _
+        FindLatestVersion = FindLatestForArch(candidates, prefix, "")
+End Function
+
+' Picks the version code to install for the native architecture, given the available cache.
+Function ResolveArchCode(version, versions)
+    Dim candidate
+    candidate = CheckArch(version)
+
+    If versions.Exists(candidate) Then
+        ResolveArchCode = candidate
+    ElseIf IsArm() And Not HasArchPostfix(version) Then
+        ResolveArchCode = version
+    Else
+        ResolveArchCode = ""
+    End If
 End Function
 
 Function TryResolveVersion(prefix, known)

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -513,21 +513,32 @@ Function FindLatestVersion(prefix, known)
 End Function
 
 ' Picks the version code to install for the native architecture, given the available cache.
+' Returns "" when the cache entry cannot run on this machine.
 Function ResolveArchCode(version, versions)
     Dim candidate
-    candidate = CheckArch(version)
+    ResolveArchCode = ""
 
+    ' An explicit architecture is honoured as-is, so --32only still works on ARM64.
+    If HasArchPostfix(version) Then
+        If IsRunnableArch(version) Then ResolveArchCode = version
+        Exit Function
+    End If
+
+    candidate = CheckArch(version)
     If versions.Exists(candidate) Then
         ResolveArchCode = candidate
-    ElseIf IsArm() And Not HasArchPostfix(version) Then
+    ElseIf IsRunnableArch(version) Then
+        ' No native build published; the x64 build runs under emulation.
         ResolveArchCode = version
-    Else
-        ResolveArchCode = ""
     End If
 End Function
 
 Function TryResolveVersion(prefix, known)
     Dim resolved
+
+    ' Installer filenames use -arm64; version codes use -arm. Accept either from the user.
+    If Right(LCase(prefix), 6) = "-arm64" Then _
+        prefix = Left(prefix, Len(prefix) - 6) & "-arm"
 
     resolved = FindLatestVersion(prefix, known)
 

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -480,11 +480,52 @@ Function FindLatestForArch(candidates, prefix, arch)
     End If
 End Function
 
+' Splits a trailing architecture postfix off a user-supplied version reference, so that a
+' partial request like "3.11-arm" resolves as prefix "3.11" filtered to the ARM builds.
+' Returns True when one was found; bare and archPostfix receive the two halves.
+Function ExtractArchPostfix(ByRef bare, ByRef archPostfix)
+    Dim lower, stripped, postfix, found
+    lower = LCase(bare)
+    found = True
+
+    If Right(lower, 6) = "-arm64" Then
+        postfix = "-arm" : stripped = Left(bare, Len(bare) - 6)
+    ElseIf Right(lower, 4) = "-arm" Then
+        postfix = "-arm" : stripped = Left(bare, Len(bare) - 4)
+    ElseIf Right(lower, 6) = "-win32" Then
+        postfix = "-win32" : stripped = Left(bare, Len(bare) - 6)
+    ElseIf Right(lower, 6) = "-amd64" Then
+        postfix = "" : stripped = Left(bare, Len(bare) - 6)
+    Else
+        found = False
+    End If
+
+    ' Only CPython codes carry an architecture postfix; pypy and graalpy codes such as
+    ' "graalpy-24.0.1-windows-amd64" embed those words in the name itself.
+    If found Then found = regexVer.Test(stripped)
+
+    If found Then
+        bare = stripped
+        archPostfix = postfix
+    Else
+        archPostfix = ""
+    End If
+    ExtractArchPostfix = found
+End Function
+
 ' Resolves latest python version by given prefix
 ' known=False to find latest _installed_ version
 ' See `pyenv latest --help`
 Function FindLatestVersion(prefix, known)
     Dim candidates
+    Dim bare
+    Dim explicitArch
+    Dim pinned
+
+    bare = prefix
+    ' An explicitly requested architecture is honoured exactly, with no emulation fallback.
+    pinned = ExtractArchPostfix(bare, explicitArch)
+    If Not pinned Then explicitArch = GetArchPostfix()
 
     if known Then
         Dim cachedVersions
@@ -505,11 +546,12 @@ Function FindLatestVersion(prefix, known)
         candidates = GetInstalledVersions()
     end if
 
-    FindLatestVersion = FindLatestForArch(candidates, prefix, GetArchPostfix())
+    FindLatestVersion = FindLatestForArch(candidates, bare, explicitArch)
+    If pinned Then Exit Function
 
     ' Not every release ships a native ARM64 build; the x64 build runs under emulation.
     If FindLatestVersion = "" And IsArm() Then _
-        FindLatestVersion = FindLatestForArch(candidates, prefix, "")
+        FindLatestVersion = FindLatestForArch(candidates, bare, "")
 End Function
 
 ' Picks the version code to install for the native architecture, given the available cache.
@@ -535,10 +577,6 @@ End Function
 
 Function TryResolveVersion(prefix, known)
     Dim resolved
-
-    ' Installer filenames use -arm64; version codes use -arm. Accept either from the user.
-    If Right(LCase(prefix), 6) = "-arm64" Then _
-        prefix = Left(prefix, Len(prefix) - 6) & "-arm"
 
     resolved = FindLatestVersion(prefix, known)
 

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -229,7 +229,7 @@ Function LoadVersionsXML(xmlPath)
             CBool(version.getAttribute("webInstall")), _
             CBool(version.getAttribute("msi")), _
             zipRootDir, _
-            (Right(LCase(code), 4) = "-arm") _
+            IsArmCode(code) _
         )
     Next
 End Function

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -45,19 +45,12 @@ Const IP_InstallFile = 9
 Const IP_Quiet = 10
 Const IP_Dev = 11
 
-Dim regexVer
 Dim regexVerArch
 Dim regexFile
 Dim regexJsonUrl
-Set regexVer = New RegExp
 Set regexVerArch = New RegExp
 Set regexFile = New RegExp
 Set regexJsonUrl = New RegExp
-With regexVer
-    .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?$"
-    .Global = True
-    .IgnoreCase = True
-End With
 With regexVerArch
     ' "-arm" is the canonical postfix emitted by JoinWin32String; the others are accepted as user input.
     .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?([\.-](?:amd64|arm64|arm|win32))?$"
@@ -484,17 +477,20 @@ End Function
 ' partial request like "3.11-arm" resolves as prefix "3.11" filtered to the ARM builds.
 ' Returns True when one was found; bare and archPostfix receive the two halves.
 Function ExtractArchPostfix(ByRef bare, ByRef archPostfix)
-    Dim lower, candidate, stripped, postfix, found
-    candidate = NormalizeArchPostfix(bare)
-    lower = LCase(candidate)
+    Dim lower, stripped, postfix, found
+    lower = LCase(bare)
     found = True
 
-    If Right(lower, 4) = "-arm" Then
-        postfix = "-arm" : stripped = Left(candidate, Len(candidate) - 4)
+    ' Not NormalizeArchPostfix: that collapses -amd64 to a bare code, which would lose the
+    ' fact that x64 was pinned and let the native postfix be applied instead.
+    If Right(lower, 6) = "-arm64" Then
+        postfix = "-arm" : stripped = Left(bare, Len(bare) - 6)
+    ElseIf Right(lower, 4) = "-arm" Then
+        postfix = "-arm" : stripped = Left(bare, Len(bare) - 4)
     ElseIf Right(lower, 6) = "-win32" Then
-        postfix = "-win32" : stripped = Left(candidate, Len(candidate) - 6)
+        postfix = "-win32" : stripped = Left(bare, Len(bare) - 6)
     ElseIf Right(lower, 6) = "-amd64" Then
-        postfix = "" : stripped = Left(candidate, Len(candidate) - 6)
+        postfix = "" : stripped = Left(bare, Len(bare) - 6)
     Else
         found = False
     End If

--- a/pyenv-win/libexec/libs/pyenv-install-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-install-lib.vbs
@@ -484,18 +484,17 @@ End Function
 ' partial request like "3.11-arm" resolves as prefix "3.11" filtered to the ARM builds.
 ' Returns True when one was found; bare and archPostfix receive the two halves.
 Function ExtractArchPostfix(ByRef bare, ByRef archPostfix)
-    Dim lower, stripped, postfix, found
-    lower = LCase(bare)
+    Dim lower, candidate, stripped, postfix, found
+    candidate = NormalizeArchPostfix(bare)
+    lower = LCase(candidate)
     found = True
 
-    If Right(lower, 6) = "-arm64" Then
-        postfix = "-arm" : stripped = Left(bare, Len(bare) - 6)
-    ElseIf Right(lower, 4) = "-arm" Then
-        postfix = "-arm" : stripped = Left(bare, Len(bare) - 4)
+    If Right(lower, 4) = "-arm" Then
+        postfix = "-arm" : stripped = Left(candidate, Len(candidate) - 4)
     ElseIf Right(lower, 6) = "-win32" Then
-        postfix = "-win32" : stripped = Left(bare, Len(bare) - 6)
+        postfix = "-win32" : stripped = Left(candidate, Len(candidate) - 6)
     ElseIf Right(lower, 6) = "-amd64" Then
-        postfix = "" : stripped = Left(bare, Len(bare) - 6)
+        postfix = "" : stripped = Left(candidate, Len(candidate) - 6)
     Else
         found = False
     End If

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -453,22 +453,29 @@ Function IsArm()
     IsArm = (GetNativeArch() = "ARM64")
 End Function
 
+' True when a version code names an ARM64 build. CPython codes end in -arm, while the
+' pypy/graalpy archive codes keep their upstream "-windows-aarch64" naming.
+Function IsArmCode(version)
+    Dim lower
+    lower = LCase(version)
+    IsArmCode = (Right(lower, 4) = "-arm") Or (Right(lower, 6) = "-arm64") _
+        Or (Right(lower, 8) = "-aarch64")
+End Function
+
 ' True when the version code already carries an architecture postfix.
 Function HasArchPostfix(version)
     Dim lower
     lower = LCase(version)
-    HasArchPostfix = (Right(lower, 6) = "-win32") Or (Right(lower, 4) = "-arm")
+    HasArchPostfix = (Right(lower, 6) = "-win32") Or IsArmCode(version)
 End Function
 
 ' True when a build with this version code can execute on the current machine.
 ' 32-bit runs everywhere (WoW64 on x64, emulation on ARM64) and ARM64 emulates x64,
 ' but x64 and ARM64 builds cannot run on x86.
 Function IsRunnableArch(version)
-    Dim lower
-    lower = LCase(version)
-    If Right(lower, 4) = "-arm" Then
+    If IsArmCode(version) Then
         IsRunnableArch = IsArm()
-    ElseIf Right(lower, 6) = "-win32" Then
+    ElseIf Right(LCase(version), 6) = "-win32" Then
         IsRunnableArch = True
     Else
         IsRunnableArch = Not Is32Bit()

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -475,20 +475,30 @@ Function IsRunnableArch(version)
     End If
 End Function
 
-' Append the native architecture postfix to a version code.
+' Append the native architecture postfix to a bare version code. A code that already names
+' an architecture is left alone, so an explicit request survives on any host.
 Function CheckArch(version)
     Dim postfix
-    postfix = GetArchPostfix()
     CheckArch = version
-    If postfix = "" Then Exit Function
-    If Right(LCase(version), Len(postfix)) = postfix Then Exit Function
-    CheckArch = version & postfix
+    If HasArchPostfix(version) Then Exit Function
+    postfix = GetArchPostfix()
+    If postfix <> "" Then CheckArch = version & postfix
+End Function
+
+' Installer filenames use -arm64 while version codes use -arm; accept either from the user.
+Function NormalizeArchPostfix(version)
+    If Right(LCase(version), 6) = "-arm64" Then
+        NormalizeArchPostfix = Left(version, Len(version) - 6) & "-arm"
+    Else
+        NormalizeArchPostfix = version
+    End If
 End Function
 
 ' Like CheckArch, but keeps the bare code when no native build is installed.
 ' ARM64 runs x64 builds under emulation, so those remain valid targets.
-Function CheckArchInstalled(version)
+Function CheckArchInstalled(ByVal version)
     Dim candidate
+    version = NormalizeArchPostfix(version)
     candidate = CheckArch(version)
     If Not IsArm() Then
         CheckArchInstalled = candidate

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -426,30 +426,60 @@ Sub Rehash()
     Next
 End Sub
 
+' SYSTEM:PROCESSOR_ARCHITECTURE is the native architecture of the machine,
+' unaffected by the bitness of the running cscript.exe.
+Function GetNativeArch()
+    GetNativeArch = objws.Environment("Process")("PYENV_FORCE_ARCH")
+    If GetNativeArch = "" Then _
+        GetNativeArch = objws.Environment("System")("PROCESSOR_ARCHITECTURE")
+    GetNativeArch = UCase(GetNativeArch)
+End Function
+
+' Postfix used in version codes, matching JoinWin32String in pyenv-install-lib.vbs.
 Function GetArchPostfix()
-    Dim arch
-
-    arch = objws.Environment("Process")("PYENV_FORCE_ARCH")
-    If arch = "" Then arch = objws.Environment("System")("PROCESSOR_ARCHITECTURE")
-
-    If UCase(arch) = "AMD64" Then GetArchPostfix = ""
-    If UCase(arch) = "X86"   Then GetArchPostfix = "-win32"
-    If UCase(arch) = "ARM64" Then GetArchPostfix = "-arm64"  ' NOT TESTED
+    Select Case GetNativeArch()
+        Case "AMD64" GetArchPostfix = ""
+        Case "X86"   GetArchPostfix = "-win32"
+        Case "ARM64" GetArchPostfix = "-arm"
+        Case Else    GetArchPostfix = ""
+    End Select
 End Function
 
-' SYSTEM:PROCESSOR_ARCHITECTURE = AMD64 on 64-bit computers. (even when using 32-bit cmd.exe)
 Function Is32Bit()
-    ' WScript.echo "kkotari: pyenv-lib.vbs is32bit..!"
-    Dim arch
-    arch = objws.Environment("Process")("PYENV_FORCE_ARCH")
-    If arch = "" Then arch = objws.Environment("System")("PROCESSOR_ARCHITECTURE")
-    Is32Bit = (UCase(arch) = "X86")
+    Is32Bit = (GetNativeArch() = "X86")
 End Function
 
-' If on a 32bit computer, default to -win32 versions.
-Function Check32Bit(version)
-    ' WScript.echo "kkotari: pyenv-lib.vbs check32bit..!"
-    If Is32Bit And Right(LCase(version), 6) <> "-win32" Then _
-        version = version & "-win32"
-    Check32Bit = version
+Function IsArm()
+    IsArm = (GetNativeArch() = "ARM64")
+End Function
+
+' True when the version code already carries an architecture postfix.
+Function HasArchPostfix(version)
+    Dim lower
+    lower = LCase(version)
+    HasArchPostfix = (Right(lower, 6) = "-win32") Or (Right(lower, 4) = "-arm")
+End Function
+
+' Append the native architecture postfix to a version code.
+Function CheckArch(version)
+    Dim postfix
+    postfix = GetArchPostfix()
+    CheckArch = version
+    If postfix = "" Then Exit Function
+    If Right(LCase(version), Len(postfix)) = postfix Then Exit Function
+    CheckArch = version & postfix
+End Function
+
+' Like CheckArch, but keeps the bare code when no native build is installed.
+' ARM64 runs x64 builds under emulation, so those remain valid targets.
+Function CheckArchInstalled(version)
+    Dim candidate
+    candidate = CheckArch(version)
+    If Not IsArm() Then
+        CheckArchInstalled = candidate
+    ElseIf objfs.FolderExists(strDirVers &"\"& candidate) Then
+        CheckArchInstalled = candidate
+    Else
+        CheckArchInstalled = version
+    End If
 End Function

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -3,11 +3,20 @@ Option Explicit
 Dim objfs
 Dim objws
 Dim objweb
+Dim regexVer
 
 ' WScript.echo "kkotari: pyenv-lib.vbs..!"
 Set objfs = CreateObject("Scripting.FileSystemObject")
 Set objws = WScript.CreateObject("WScript.Shell")
 Set objweb = CreateObject("WinHttp.WinHttpRequest.5.1")
+
+' A bare CPython version code like 3, 3.11, 3.11.0 or 3.11.0rc1
+Set regexVer = New RegExp
+With regexVer
+    .Pattern = "^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:([a-z]+)(\d*))?$"
+    .Global = True
+    .IgnoreCase = True
+End With
 
 ' Set proxy settings, called on library import for objweb.
 Sub SetProxy()
@@ -492,12 +501,22 @@ Function CheckArch(version)
     If postfix <> "" Then CheckArch = version & postfix
 End Function
 
-' Installer filenames use -arm64 while version codes use -arm; accept either from the user.
+' Installer filenames can have postfixes like -arm64 and -amd64, while version codes use
+' -arm and a bare name. Accept either spelling, but only for CPython codes: pypy and
+' graalpy archive codes such as graalpy-24.2.0-windows-amd64 remain unchanged.
 Function NormalizeArchPostfix(version)
-    If Right(LCase(version), 6) = "-arm64" Then
-        NormalizeArchPostfix = Left(version, Len(version) - 6) & "-arm"
+    Dim lower, stripped
+    lower = LCase(version)
+    NormalizeArchPostfix = version
+
+    If Right(lower, 6) <> "-arm64" And Right(lower, 6) <> "-amd64" Then Exit Function
+    stripped = Left(version, Len(version) - 6)
+    If Not regexVer.Test(stripped) Then Exit Function
+
+    If Right(lower, 6) = "-arm64" Then
+        NormalizeArchPostfix = stripped & "-arm"
     Else
-        NormalizeArchPostfix = version
+        NormalizeArchPostfix = stripped
     End If
 End Function
 
@@ -505,13 +524,21 @@ End Function
 ' ARM64 runs x64 builds under emulation, so those remain valid targets.
 Function CheckArchInstalled(ByVal version)
     Dim candidate
-    version = NormalizeArchPostfix(version)
-    candidate = CheckArch(version)
+    Dim normalized
+    normalized = NormalizeArchPostfix(version)
+
+    ' An explicitly named architecture is final; only a bare code prefers the native build.
+    If normalized <> version Or HasArchPostfix(normalized) Then
+        CheckArchInstalled = normalized
+        Exit Function
+    End If
+
+    candidate = CheckArch(normalized)
     If Not IsArm() Then
         CheckArchInstalled = candidate
     ElseIf objfs.FolderExists(strDirVers &"\"& candidate) Then
         CheckArchInstalled = candidate
     Else
-        CheckArchInstalled = version
+        CheckArchInstalled = normalized
     End If
 End Function

--- a/pyenv-win/libexec/libs/pyenv-lib.vbs
+++ b/pyenv-win/libexec/libs/pyenv-lib.vbs
@@ -460,6 +460,21 @@ Function HasArchPostfix(version)
     HasArchPostfix = (Right(lower, 6) = "-win32") Or (Right(lower, 4) = "-arm")
 End Function
 
+' True when a build with this version code can execute on the current machine.
+' 32-bit runs everywhere (WoW64 on x64, emulation on ARM64) and ARM64 emulates x64,
+' but x64 and ARM64 builds cannot run on x86.
+Function IsRunnableArch(version)
+    Dim lower
+    lower = LCase(version)
+    If Right(lower, 4) = "-arm" Then
+        IsRunnableArch = IsArm()
+    ElseIf Right(lower, 6) = "-win32" Then
+        IsRunnableArch = True
+    Else
+        IsRunnableArch = Not Is32Bit()
+    End If
+End Function
+
 ' Append the native architecture postfix to a version code.
 Function CheckArch(version)
     Dim postfix

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -416,8 +416,17 @@ Sub main(arg)
         opt64 = False
         optArm = False
     End If
-    If CInt(opt32) + CInt(opt64) + CInt(optArm) < -1 Then
+    Dim archOpts
+    archOpts = 0
+    If opt32 Then archOpts = archOpts + 1
+    If opt64 Then archOpts = archOpts + 1
+    If optArm Then archOpts = archOpts + 1
+    If archOpts > 1 Then
         WScript.Echo "pyenv-install: only one of --32only, --64only or --armonly may be specified."
+        WScript.Quit 1
+    End If
+    If optArm And Not IsArm Then
+        WScript.Echo "pyenv-install: --armonly is only supported on ARM64 Windows."
         WScript.Quit 1
     End If
     If optReg Then
@@ -472,24 +481,28 @@ Sub main(arg)
     End If
 
     If optAll Then
-        ' Add all versions, but only versions runnable on this platform.
-        ' --32only/--64only/--armonly is disabled on 32-bit platforms.
+        ' Add every version this machine can run, honouring an explicit architecture filter.
         installVersions.RemoveAll
         For Each version In versions.Keys
-            version = ResolveArchCode(version, versions)
-            If versions.Exists(version) Then
-                If opt64 Then
-                    If versions(version)(LV_x64) And Not versions(version)(LV_ARM) Then _
-                        installVersions(version) = Empty
-                ElseIf opt32 Then
-                    If Not versions(version)(LV_x64) Then _
-                        installVersions(version) = Empty
-                ElseIf optArm Then
-                    If versions(version)(LV_ARM) Then _
-                        installVersions(version) = Empty
-                Else
-                    installVersions(version) = Empty
+            If opt32 Or opt64 Or optArm Then
+                ' Filter the cache keys directly: resolving to the native build first would
+                ' hide the x64 records behind their -arm counterparts on ARM64.
+                If IsRunnableArch(version) Then
+                    If opt64 Then
+                        If versions(version)(LV_x64) And Not versions(version)(LV_ARM) Then _
+                            installVersions(version) = Empty
+                    ElseIf opt32 Then
+                        If Not versions(version)(LV_x64) Then _
+                            installVersions(version) = Empty
+                    Else
+                        If versions(version)(LV_ARM) Then _
+                            installVersions(version) = Empty
+                    End If
                 End If
+            Else
+                version = ResolveArchCode(version, versions)
+                If versions.Exists(version) Then _
+                    installVersions(version) = Empty
             End If
         Next
     Else
@@ -512,6 +525,10 @@ Sub main(arg)
             WScript.Echo
             WScript.Echo "See all available versions with `pyenv install --list`."
             WScript.Echo "Does the list seem out of date? Update it using `pyenv update`."
+            WScript.Quit 1
+        End If
+        If Not IsRunnableArch(version) Then
+            WScript.Echo "pyenv-install: "& version &" cannot run on "& GetNativeArch() &" Windows."
             WScript.Quit 1
         End If
     Next

--- a/pyenv-win/libexec/pyenv-install.vbs
+++ b/pyenv-win/libexec/pyenv-install.vbs
@@ -24,7 +24,7 @@ Next
 Sub ShowHelp()
     ' WScript.echo "kkotari: pyenv-install.vbs..!"
     WScript.Echo "Usage: pyenv install [-s] [-f] <version> [<version> ...] [-r|--register]"
-    WScript.Echo "       pyenv install [-f] [--32only|--64only] -a|--all"
+    WScript.Echo "       pyenv install [-f] [--32only|--64only|--armonly] -a|--all"
     WScript.Echo "       pyenv install [-f] -c|--clear"
     WScript.Echo "       pyenv install -l|--list"
     WScript.Echo ""
@@ -36,7 +36,8 @@ Sub ShowHelp()
     WScript.Echo "  -r/--register          Register version for py launcher"
     WScript.Echo "  -q/--quiet             Install using /quiet. This does not show the UI nor does it prompt for inputs"
     WScript.Echo "  --32only               Installs only 32bit Python using -a/--all switch, no effect on 32-bit windows."
-    WScript.Echo "  --64only               Installs only 64bit Python using -a/--all switch, no effect on 32-bit windows."
+    WScript.Echo "  --64only               Installs only 64bit x64 Python using -a/--all switch, no effect on 32-bit windows."
+    WScript.Echo "  --armonly              Installs only ARM64 Python using -a/--all switch, no effect on 32-bit windows."
     WScript.Echo "  --dev                  Installs precompiled standard libraries, debug symbols, and debug binaries (only applies to web installer)."
     WScript.Echo "  --help                 Help, list of options allowed on pyenv install"
     WScript.Echo ""
@@ -217,8 +218,8 @@ Sub registerVersion(version, installPath)
     Set sh = CreateObject("WScript.Shell")
     Set env = sh.Environment("Process")
     Dim arch
-    arch = env("PROCESSOR_ARCHITECTURE")
-    if arch = "x86" Then
+    arch = UCase(env("PROCESSOR_ARCHITECTURE"))
+    if arch = "X86" Then
         WScript.Echo "Python registration not supported in 32 bits"
         Exit Sub
     End If
@@ -236,15 +237,22 @@ Sub registerVersion(version, installPath)
     sysVersion = parts(0) &"."& parts(1)
     featureVersion = parts(0) &"."& parts(1) &"."& parts(2) &".0"
 
-    dim bitDepth, versionAttribute
+    dim sysArch, displayArch, versionAttribute
 
+    ' SysArchitecture values understood by the py launcher: 32bit, 64bit, ARM64.
     If InStr(version, "-win32") Then
-        bitDepth = "32"
+        sysArch = "32bit"
+        displayArch = "32-bit"
         versionAttribute = Replace(version, "-win32", "")
+    ElseIf Right(LCase(version), 4) = "-arm" Then
+        sysArch = "ARM64"
+        displayArch = "ARM64"
+        versionAttribute = Left(version, Len(version) - 4)
     Else
-        bitDepth = "64"
+        sysArch = "64bit"
+        displayArch = "64-bit"
         versionAttribute = version
-    End If     
+    End If
 
     key = "HKCU\SOFTWARE\Python\PythonCore\"
     ' I prefer not overriding default Python registry values (that might already exist)
@@ -253,9 +261,9 @@ Sub registerVersion(version, installPath)
     ' http://www.python.org/
     'sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
     key = key & version &"\"
-    sh.RegWrite key & "DisplayName","Python "& sysVersion &" (" & bitDepth & "-bit)","REG_SZ"
+    sh.RegWrite key & "DisplayName","Python "& sysVersion &" (" & displayArch & ")","REG_SZ"
     sh.RegWrite key & "SupportUrl","https://github.com/pyenv-win/pyenv-win/issues","REG_SZ"
-    sh.RegWrite key & "SysArchitecture",bitDepth & "bit","REG_SZ"
+    sh.RegWrite key & "SysArchitecture",sysArch,"REG_SZ"
     sh.RegWrite key & "SysVersion",sysVersion,"REG_SZ"
     sh.RegWrite key & "Version",versionAttribute,"REG_SZ"
     ' python only (not pypy)
@@ -359,6 +367,7 @@ Sub main(arg)
     Dim optAll
     Dim opt32
     Dim opt64
+    Dim optArm
     Dim optDev
     Dim optReg
     Dim optClear
@@ -371,6 +380,7 @@ Sub main(arg)
     optAll = False
     opt32 = False
     opt64 = False
+    optArm = False
     optDev = False
     optReg = False
     Set installVersions = CreateObject("Scripting.Dictionary")
@@ -392,6 +402,8 @@ Sub main(arg)
             Case "--clear"          optClear = True
             Case "--32only"         opt32 = True
             Case "--64only"         opt64 = True
+            Case "--armonly"        optArm = True
+            Case "--arm64only"      optArm = True
             Case "--dev"            optDev = True
             Case "-r"               optReg = True
             Case "--register"       optReg = True
@@ -402,9 +414,10 @@ Sub main(arg)
     If Is32Bit Then
         opt32 = False
         opt64 = False
+        optArm = False
     End If
-    If opt32 And opt64 Then
-        WScript.Echo "pyenv-install: only --32only or --64only may be specified, not both."
+    If CInt(opt32) + CInt(opt64) + CInt(optArm) < -1 Then
+        WScript.Echo "pyenv-install: only one of --32only, --64only or --armonly may be specified."
         WScript.Quit 1
     End If
     If optReg Then
@@ -459,17 +472,20 @@ Sub main(arg)
     End If
 
     If optAll Then
-        ' Add all versions, but only 32-bit versions for 32-bit platforms.
-        ' --32only/--64only is disabled on 32-bit platforms.
+        ' Add all versions, but only versions runnable on this platform.
+        ' --32only/--64only/--armonly is disabled on 32-bit platforms.
         installVersions.RemoveAll
         For Each version In versions.Keys
-            version = Check32Bit(version)
+            version = ResolveArchCode(version, versions)
             If versions.Exists(version) Then
                 If opt64 Then
-                    If versions(version)(LV_x64) Then _
+                    If versions(version)(LV_x64) And Not versions(version)(LV_ARM) Then _
                         installVersions(version) = Empty
                 ElseIf opt32 Then
                     If Not versions(version)(LV_x64) Then _
+                        installVersions(version) = Empty
+                ElseIf optArm Then
+                    If versions(version)(LV_ARM) Then _
                         installVersions(version) = Empty
                 Else
                     installVersions(version) = Empty
@@ -516,6 +532,7 @@ Sub main(arg)
                 verDef(LV_Web), _
                 verDef(LV_MSI), _
                 verDef(LV_ZipRootDir), _
+                verDef(LV_ARM), _
                 strDirVers &"\"& verDef(LV_Code), _
                 strDirCache &"\"& verDef(LV_FileName), _
                 optQuiet, _

--- a/pyenv-win/libexec/pyenv-uninstall.vbs
+++ b/pyenv-win/libexec/pyenv-uninstall.vbs
@@ -101,7 +101,7 @@ Sub main(arg)
     End If
 
     If uninstallVersions.Count = 1 Then
-        folder = Check32Bit(uninstallVersions.Keys()(0))
+        folder = CheckArchInstalled(uninstallVersions.Keys()(0))
         If Not objfs.FolderExists(strDirVers &"\"& folder) Then
             WScript.Echo "pyenv: version '"& folder &"' not installed"
             Exit Sub
@@ -114,7 +114,7 @@ Sub main(arg)
 
     On Error Resume Next
     For Each folder In uninstallVersions.Keys
-        folder = Check32Bit(folder)
+        folder = CheckArchInstalled(folder)
 
         If Not uninstalled.Exists(folder) Then
             uninstallPath = strDirVers &"\"& folder

--- a/pyenv-win/libexec/pyenv-uninstall.vbs
+++ b/pyenv-win/libexec/pyenv-uninstall.vbs
@@ -34,11 +34,13 @@ Sub unregister(version)
     Dim sh, key
     Set sh = CreateObject("WScript.Shell")
     key = "HKCU\SOFTWARE\Python\PythonCore\"& version &"\"
-    ' No problem removing keys that do not exist
+    ' Versions installed without -r were never registered, so ignore any RegDelete errors.
+    On Error Resume Next
     sh.RegDelete key & "InstallPath\"
     sh.RegDelete key & "InstalledFeatures\"
     sh.RegDelete key & "PythonPath\"
     sh.RegDelete key
+    Err.Clear
 End Sub
 
 Sub main(arg)
@@ -100,7 +102,8 @@ Sub main(arg)
         Next
     End If
 
-    If uninstallVersions.Count = 1 Then
+    ' --all enumerates real folder names, so only user-supplied names need resolving.
+    If uninstallVersions.Count = 1 And Not optAll Then
         folder = CheckArchInstalled(uninstallVersions.Keys()(0))
         If Not objfs.FolderExists(strDirVers &"\"& folder) Then
             WScript.Echo "pyenv: version '"& folder &"' not installed"
@@ -114,7 +117,7 @@ Sub main(arg)
 
     On Error Resume Next
     For Each folder In uninstallVersions.Keys
-        folder = CheckArchInstalled(folder)
+        If Not optAll Then folder = CheckArchInstalled(folder)
 
         If Not uninstalled.Exists(folder) Then
             uninstallPath = strDirVers &"\"& folder

--- a/pyenv-win/libexec/pyenv.vbs
+++ b/pyenv-win/libexec/pyenv.vbs
@@ -420,7 +420,7 @@ Sub CommandShell(arg)
             ReDim shellVersions(versionCount - 1)
             Dim i
             For i = 0 To versionCount - 1
-                shellVersions(i) = Check32Bit(arg(i + 1))
+                shellVersions(i) = CheckArchInstalled(arg(i + 1))
                 GetBinDir(shellVersions(i))
             Next
         End If

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,12 +60,12 @@ def pyenv_file(shell, bin_path, shell_ext):
     return pyenv_file
 
 
-@pytest.fixture(scope='session', autouse=True, params=['AMD64', 'X86'],
-                ids=['PYENV_FORCE_ARCH=AMD64', 'PYENV_FORCE_ARCH=X86'])
+@pytest.fixture(scope='session', autouse=True, params=['AMD64', 'X86', 'ARM64'],
+                ids=['PYENV_FORCE_ARCH=AMD64', 'PYENV_FORCE_ARCH=X86', 'PYENV_FORCE_ARCH=ARM64'])
 def arch(request):
     value = request.param
     if request.session.testsfailed:
-        pytest.skip(f'Skipping PYENV_FORCE_ARCH={value} since at lease one test failed for PYENV_FORCE_ARCH=AMD64')
+        pytest.skip(f'Skipping PYENV_FORCE_ARCH={value} since at least one test failed for an earlier architecture')
     with(TemporaryEnvironment({'PYENV_FORCE_ARCH': value})):
         yield value
 

--- a/tests/test_pyenv_feature_install.py
+++ b/tests/test_pyenv_feature_install.py
@@ -1,7 +1,7 @@
 import pytest
 
 import os
-from test_pyenv_helpers import Native
+from test_pyenv_helpers import Arch, Native
 
 
 def test_check_pyenv_install_list(pyenv):
@@ -30,6 +30,8 @@ def test_check_pyenv_install_list(pyenv):
     assert "3.9.0" in result
     assert "3.9.1-win32" in result
     assert "3.9.1" in result
+    assert "3.11.0-arm" in result
+    assert "3.12.0-arm" in result
     assert "graalpy" in result
     assert "pypy" in result
 
@@ -43,9 +45,14 @@ def test_check_pyenv_installation():
 def test_patched_venv_module(version, python, arch, pyenv, run, tmp_path):
     if arch != os.environ["PROCESSOR_ARCHITECTURE"]:
         pytest.skip()
-    pyenv.install(Native(version), check=True)
+    # python.org ships native ARM64 builds from 3.11 on; older releases resolve to the emulated x64 build.
+    if arch == 'ARM64' and tuple(int(p) for p in version.split('.')[:2]) < (3, 11):
+        expected = Arch(version)
+    else:
+        expected = Native(version)
+    pyenv.install(expected, check=True)
     pyenv.rehash(check=True)
-    pyenv("global", Native(version), check=True)
+    pyenv("global", expected, check=True)
     pyenv.exec(python, "-m", "venv", str(tmp_path / "venv"), check=True)
     stdout, stderr = run(str(tmp_path / "venv" / "Scripts" / "pip.exe"), "--version")
     assert stderr == "", stdout

--- a/tests/test_pyenv_feature_latest.py
+++ b/tests/test_pyenv_feature_latest.py
@@ -1,5 +1,5 @@
 import pytest
-from test_pyenv_helpers import Native, X86, Arch
+from test_pyenv_helpers import Native, X86, Arm, Arch
 
 
 def test_latest_help(pyenv):
@@ -35,7 +35,29 @@ def test_latest_arch_cases(pyenv, current_arch):
     if current_arch == 'X86':
         assert pyenv.latest("3.1") == (X86("3.1.0"), "")
     else:
-        assert pyenv.latest("3.1") == (Native("3.1.4"), "")
+        # No -arm build is installed here, so ARM64 resolves to the x64 build too.
+        assert pyenv.latest("3.1") == (Arch("3.1.4"), "")
+
+
+@pytest.mark.parametrize('settings', [lambda: {
+        'versions': [X86("3.1.0"), Arch("3.1.4"), Arm("3.1.2")]
+    }])
+def test_latest_prefers_native_arm(pyenv, current_arch):
+    if current_arch == 'X86':
+        assert pyenv.latest("3.1") == (X86("3.1.0"), "")
+    elif current_arch == 'ARM64':
+        assert pyenv.latest("3.1") == (Arm("3.1.2"), "")
+    else:
+        assert pyenv.latest("3.1") == (Arch("3.1.4"), "")
+
+
+@pytest.mark.parametrize('settings', [lambda: {
+        'versions': [Arch("3.1.4")]
+    }])
+def test_latest_arm_falls_back_to_x64(pyenv, current_arch):
+    if current_arch == 'X86':
+        pytest.skip('x86 cannot run x64 builds')
+    assert pyenv.latest("3.1") == (Arch("3.1.4"), "")
 
 
 def test_latest_quiet(pyenv):

--- a/tests/test_pyenv_feature_latest.py
+++ b/tests/test_pyenv_feature_latest.py
@@ -60,6 +60,25 @@ def test_latest_arm_falls_back_to_x64(pyenv, current_arch):
     assert pyenv.latest("3.1") == (Arch("3.1.4"), "")
 
 
+@pytest.mark.parametrize('settings', [lambda: {
+        'versions': [X86("3.1.0"), Arch("3.1.4"), Arm("3.1.2")]
+    }])
+def test_latest_partial_prefix_with_arch(pyenv):
+    # A pinned architecture applies to the prefix search, whatever the host is.
+    assert pyenv.latest("3.1-win32") == (X86("3.1.0"), "")
+    assert pyenv.latest("3.1-arm") == (Arm("3.1.2"), "")
+    assert pyenv.latest("3.1-arm64") == (Arm("3.1.2"), "")
+    assert pyenv.latest("3.1-amd64") == (Arch("3.1.4"), "")
+
+
+@pytest.mark.parametrize('settings', [lambda: {
+        'versions': [X86("3.1.0"), Arch("3.1.4")]
+    }])
+def test_latest_pinned_arch_does_not_fall_back(pyenv):
+    # No ARM build is installed, and an explicit request must not silently pick another.
+    assert pyenv.latest("3.1-arm") == ("pyenv-latest: no installed versions match the prefix '3.1-arm'.", "")
+
+
 def test_latest_quiet(pyenv):
     assert pyenv.latest("-q") == ("", "")
     assert pyenv.latest("-q", "-k") == ("", "")

--- a/tests/test_pyenv_feature_shell.py
+++ b/tests/test_pyenv_feature_shell.py
@@ -92,8 +92,11 @@ def test_shell_set_many_versions(local_path, shell, shell_ext, run):
 
 
 @pytest.mark.parametrize('settings', [lambda: {'versions': [Native("3.7.7")]}])
-def test_shell_set_many_versions_one_not_installed(pyenv):
-    assert pyenv.shell(Arch("3.7.7"), Arch("3.8.9")) == (not_installed_output(Native("3.8.9")), "")
+def test_shell_set_many_versions_one_not_installed(pyenv, current_arch):
+    # ARM64 keeps the bare name: not every release has a native ARM64 build, so
+    # `pyenv install 3.8.9` is actionable where `pyenv install 3.8.9-arm` would not be.
+    expected = Arch("3.8.9") if current_arch == 'ARM64' else Native("3.8.9")
+    assert pyenv.shell(Arch("3.7.7"), Arch("3.8.9")) == (not_installed_output(expected), "")
 
 
 def test_shell_many_versions_defined(pyenv):

--- a/tests/test_pyenv_feature_uninstall.py
+++ b/tests/test_pyenv_feature_uninstall.py
@@ -1,0 +1,36 @@
+import pytest
+
+from pathlib import Path
+from test_pyenv_helpers import Arch, Arm
+
+
+def installed_versions(pyenv_path):
+    return sorted(p.name for p in Path(pyenv_path, 'versions').iterdir() if p.is_dir())
+
+
+# 9.9.9 keeps `unregister` away from any Python version a developer may have registered
+# under HKCU, since uninstall deletes those keys for real.
+@pytest.mark.parametrize('settings', [lambda: {
+        'versions': [Arch("9.9.9"), Arm("9.9.9")]
+    }])
+def test_uninstall_all_removes_every_architecture(pyenv, pyenv_path):
+    assert installed_versions(pyenv_path) == ["9.9.9", "9.9.9-arm"]
+    stdout, stderr = pyenv.uninstall("--all", "-f")
+    assert stderr == ""
+    assert installed_versions(pyenv_path) == []
+
+
+@pytest.mark.parametrize('settings', [lambda: {'versions': [Arm("9.9.9")]}])
+def test_uninstall_accepts_arm64_spelling(pyenv, pyenv_path):
+    stdout, stderr = pyenv.uninstall("-f", "9.9.9-arm64")
+    assert stderr == ""
+    assert installed_versions(pyenv_path) == []
+
+
+@pytest.mark.parametrize('settings', [lambda: {'versions': [Arm("9.9.9")]}])
+def test_uninstall_bare_name_resolves_to_native_build(pyenv, pyenv_path, current_arch):
+    if current_arch != 'ARM64':
+        pytest.skip('only ARM64 resolves a bare name to the -arm build')
+    stdout, stderr = pyenv.uninstall("-f", "9.9.9")
+    assert stderr == ""
+    assert installed_versions(pyenv_path) == []

--- a/tests/test_pyenv_helpers.py
+++ b/tests/test_pyenv_helpers.py
@@ -126,6 +126,10 @@ def do_run(*args, **kwargs):
     return stdout, stderr
 
 
+# Version code postfix per architecture, matching GetArchPostfix in pyenv-lib.vbs.
+ARCH_POSTFIX = {'AMD64': '', 'X86': '-win32', 'ARM64': '-arm'}
+
+
 class Arch(str):
     version = None
 
@@ -138,10 +142,7 @@ class Arch(str):
 class Native(Arch):
     def __new__(cls, content):
         ver = content
-        if os.environ['PYENV_FORCE_ARCH'] == 'X86':
-            content = content + '-win32'
-        if os.environ['PYENV_FORCE_ARCH'] == 'ARM64':
-            content = content + '-arm64'
+        content = content + ARCH_POSTFIX[os.environ['PYENV_FORCE_ARCH']]
         self = super().__new__(cls, content)
         self.version = ver
         return self
@@ -156,10 +157,15 @@ class X86(Arch):
         return self
 
 
-class Amd64(Arch):
+class Arm(Arch):
     def __new__(cls, content):
         ver = content
-        content = content + '-amd64'
+        content = content + '-arm'
         self = super().__new__(cls, content)
         self.version = ver
         return self
+
+
+class Amd64(Arch):
+    """x64 builds carry no postfix in pyenv version codes."""
+    pass


### PR DESCRIPTION
As the title says -- the version cache already had ARM64 releases but the install and test code was broken and could not actually install any of those.

The code was using `-arm` as the postfix for the cache but it was `-arm64` in other places. So to avoid regenerating the entire cache, I changed it to be `-arm` everywhere.

I have also updated the pytest_ps1 workflow to use the actual branch it's called from. I can remove that part if you feel that is not needed.

I also noticed that the `pyenv update` command uses MSHTML which has been out of support for years, and as such that command does not work at all. Everything else still works though because of the version cache. This produces errors like `C:\Users\runneradmin\.pyenv\pyenv-win\libexec\pyenv-update.vbs(172, 13) htmlfile: This command is not supported.`

I have tested all of this locally on my ARM64 laptop as well as GitHub Actions in my fork.